### PR TITLE
ninja中文路径编译补丁支持：BigVGAN fused cuda kernel

### DIFF
--- a/indextts/BigVGAN/alias_free_activation/cuda/load.py
+++ b/indextts/BigVGAN/alias_free_activation/cuda/load.py
@@ -14,6 +14,18 @@ Set it to empty stringo avoid recompilation and assign arch flags explicity in e
 os.environ["TORCH_CUDA_ARCH_LIST"] = ""
 
 
+# 补丁修复：sources 路径含中文字符时，生成 build.ninja 乱码导致编译失败
+def fix_write_utf8(filename, new_content):
+    if os.path.exists(filename):
+        with open(filename, encoding="utf-8") as f:
+            content = f.read()
+        if content == new_content:
+            return
+    with open(filename, 'w', encoding="utf-8") as source_file:
+        source_file.write(new_content)
+cpp_extension._maybe_write = fix_write_utf8
+
+
 def load():
     # Check if cuda 11 is installed for compute capability 8.0
     cc_flag = []

--- a/indextts/BigVGAN/alias_free_activation/cuda/load.py
+++ b/indextts/BigVGAN/alias_free_activation/cuda/load.py
@@ -14,16 +14,35 @@ Set it to empty stringo avoid recompilation and assign arch flags explicity in e
 os.environ["TORCH_CUDA_ARCH_LIST"] = ""
 
 
+import re
+import shutil
+import tempfile
+
 # 补丁修复：sources 路径含中文字符时，生成 build.ninja 乱码导致编译失败
-def fix_write_utf8(filename, new_content):
-    if os.path.exists(filename):
-        with open(filename, encoding="utf-8") as f:
-            content = f.read()
-        if content == new_content:
-            return
-    with open(filename, 'w', encoding="utf-8") as source_file:
-        source_file.write(new_content)
-cpp_extension._maybe_write = fix_write_utf8
+# 使用临时目录来规避 ninja 编译失败（比如中文路径）
+def chinese_path_compile_support(sources, buildpath):
+    pattern = re.compile(r'[\u4e00-\u9fff]')  
+    if not bool(pattern.search(str(sources[0].resolve()))):
+        return buildpath # 检测非中文路径跳过
+    # Create build directory
+    resolves = [ item.name for item in sources]
+    ninja_compile_dir = os.path.join(tempfile.gettempdir(), "BigVGAN", "cuda")
+    os.makedirs(ninja_compile_dir, exist_ok=True)
+    new_buildpath = os.path.join(ninja_compile_dir, "build")
+    os.makedirs(new_buildpath, exist_ok=True)
+    print(f"ninja_buildpath: {new_buildpath}")
+    # Copy files to directory
+    sources.clear()
+    current_dir = os.path.dirname(__file__)
+    ALLOWED_EXTENSIONS = {'.py', '.cu', '.cpp', '.h'}
+    for filename in os.listdir(current_dir):
+        item = pathlib.Path(current_dir).joinpath(filename)
+        tar_path = pathlib.Path(ninja_compile_dir).joinpath(item.name)
+        if not item.suffix.lower() in ALLOWED_EXTENSIONS:continue
+        pathlib.Path(shutil.copy2(item, tar_path))
+        if tar_path.name in resolves:sources.append(tar_path)
+    return new_buildpath
+
 
 
 def load():
@@ -70,6 +89,10 @@ def load():
         srcpath / "anti_alias_activation.cpp",
         srcpath / "anti_alias_activation_cuda.cu",
     ]
+    
+    # 兼容方案：ninja 特殊字符路径编译支持处理（比如中文路径）
+    buildpath = chinese_path_compile_support(sources, buildpath)
+    
     anti_alias_activation_cuda = _cpp_extention_load_helper(
         "anti_alias_activation_cuda", sources, extra_cuda_flags
     )


### PR DESCRIPTION
【问题复现】如果 index-tts 项目拉取在某些中文路径下，比如含中文目录：
```
j:/语音克隆/index-tts
```
当启用 use_cuda_kernel = True 时，运行项目会生成 build.ninja 中文乱码，从而导致 BigVGAN  cuda kernel 编译失败。
经过检测发现 cpp_extension.load 以及后续代码均执行失败。
```
Failed to load custom CUDA kernel for BigVGAN. Falling back to torch.
```

【补丁修复】应用此补丁，可以支持在任意中文路径下，build.ninja 正常编译 BigVGAN cuda。

```
>> Preload custom CUDA kernel for BigVGAN
```
此兼容补丁，对中文用户体验更友好，无需担心中文路径而导致 ninja 编译失败~
已更新至方案2：实测更加完美~
