### PR TITLE
批次推理：修复（漏句/丢句/音频空白）

### DIFF
--- a/indextts/infer.py
+++ b/indextts/infer.py
@@ -192,13 +192,17 @@ class IndexTTS:
         for tensor in tokens:
             pad_len = max_len - tensor.size(1)
             if pad_len > 0:
-                padded = torch.nn.functional.pad(tensor, 
-                        (0, pad_len),
+                n = min(8, pad_len)
+                tensor = torch.nn.functional.pad(tensor, 
+                        (0, n),
                         value=self.cfg.gpt.stop_text_token
                 )
-                outputs.append(padded)
-            else:
-                outputs.append(tensor)
+                tensor = torch.nn.functional.pad(tensor, 
+                        (0, pad_len - n),
+                        value=self.cfg.gpt.start_text_token
+                )
+            tensor = tensor[:,:max_len]
+            outputs.append(tensor)
         tokens = torch.cat(outputs, dim=0)
         return tokens
     

--- a/indextts/infer.py
+++ b/indextts/infer.py
@@ -185,6 +185,20 @@ class IndexTTS:
             sentence.strip() for sentence in sentences if sentence.strip() and sentence.strip() not in {"'", ".", ","}
         ]
         
+    def bucket_sentences(self, sentences, enable):
+        """
+        Sentence data bucketing
+        """
+        max_len = max(len(s) for s in sentences)
+        half = max_len // 2
+        outputs = [[],[]]
+        for idx, sent in enumerate(sentences):
+            if enable == False or len(sent) <= half:
+                outputs[0].append({"idx":idx,"sent":sent})
+            else:
+                outputs[1].append({"idx":idx,"sent":sent})
+        return [item for item in outputs if item]
+        
     def pad_tokens_cat(self, tokens):
         if len(tokens) <= 1:return tokens[-1]
         max_len = max(t.size(1) for t in tokens)
@@ -274,83 +288,98 @@ class IndexTTS:
         gpt_forward_time = 0
         bigvgan_time = 0
 
+
+        # text processing
         all_text_tokens = []
         self._set_gr_progress(0.1, "text processing...")
-        for sent in sentences:
-            # sent = " ".join([char for char in sent.upper()]) if lang == "ZH" else sent.upper()
-            cleand_text = tokenize_by_CJK_char(sent)
-            # cleand_text = "他 那 像 HONG3 小 孩 似 的 话 , 引 得 人 们 HONG1 堂 大 笑 , 大 家 听 了 一 HONG3 而 散 ."
-            if verbose:
-                print("cleand_text:", cleand_text)
-
-            text_tokens = torch.tensor(self.tokenizer.EncodeAsIds(cleand_text),dtype=torch.int32, device=self.device).unsqueeze(0)
-            # text_tokens = F.pad(text_tokens, (0, 1))  # This may not be necessary.
-            # text_tokens = F.pad(text_tokens, (1, 0), value=0)
-            # text_tokens = F.pad(text_tokens, (0, 1), value=1)
-            if verbose:
-                print(text_tokens)
-                print(f"text_tokens shape: {text_tokens.shape}, text_tokens type: {text_tokens.dtype}")
-                # debug tokenizer
-                text_token_syms = self.tokenizer.IdToPiece(text_tokens[0].tolist())
-                print(text_token_syms)
-                
-            all_text_tokens.append(text_tokens)
+        bucket_enable = True # 预分桶开关，优先保证质量=True。优先保证速度=False。
+        all_sentences = self.bucket_sentences(sentences, enable=bucket_enable) 
+        for sentences in all_sentences:
+            temp_tokens = []
+            all_text_tokens.append(temp_tokens)
+            for item in sentences:
+                sent = item["sent"]
+                # sent = " ".join([char for char in sent.upper()]) if lang == "ZH" else sent.upper()
+                cleand_text = tokenize_by_CJK_char(sent)
+                # cleand_text = "他 那 像 HONG3 小 孩 似 的 话 , 引 得 人 们 HONG1 堂 大 笑 , 大 家 听 了 一 HONG3 而 散 ."
+                if verbose:
+                    print("cleand_text:", cleand_text)
+                    
+                text_tokens = torch.tensor(self.tokenizer.EncodeAsIds(cleand_text),dtype=torch.int32, device=self.device).unsqueeze(0)
+                # text_tokens = F.pad(text_tokens, (0, 1))  # This may not be necessary.
+                # text_tokens = F.pad(text_tokens, (1, 0), value=0)
+                # text_tokens = F.pad(text_tokens, (0, 1), value=1)
+                if verbose:
+                    print(text_tokens)
+                    print(f"text_tokens shape: {text_tokens.shape}, text_tokens type: {text_tokens.dtype}")
+                    # debug tokenizer
+                    text_token_syms = self.tokenizer.IdToPiece(text_tokens[0].tolist())
+                    print(text_token_syms)
+                    
+                temp_tokens.append(text_tokens)
         
-        batch_num = len(all_text_tokens)
-        batch_text_tokens = self.pad_tokens_cat(all_text_tokens)
-        batch_cond_mel_lengths = torch.cat([cond_mel_lengths] * batch_num, dim=0)
-        batch_auto_conditioning = torch.cat([auto_conditioning] * batch_num, dim=0)
-        
-        # gpt speech
-        self._set_gr_progress(0.2, "gpt inference speech...")
-        m_start_time = time.perf_counter()
-        with torch.no_grad():
-            with torch.amp.autocast(self.device, enabled=self.dtype is not None, dtype=self.dtype):
-                batch_codes = self.gpt.inference_speech(batch_auto_conditioning, batch_text_tokens,
-                                    cond_mel_lengths=batch_cond_mel_lengths,
-                                    # text_lengths=text_len,
-                                    do_sample=True,
-                                    top_p=top_p,
-                                    top_k=top_k,
-                                    temperature=temperature,
-                                    num_return_sequences=autoregressive_batch_size,
-                                    length_penalty=length_penalty,
-                                    num_beams=num_beams,
-                                    repetition_penalty=repetition_penalty,
-                                    max_generate_length=max_mel_tokens)
-        gpt_gen_time += time.perf_counter() - m_start_time
-        
-        # clear cache
-        batch_auto_conditioning = None
-        batch_cond_mel_lengths = None
-        batch_text_tokens = None
-        self.torch_empty_cache()
-        
-        # gpt latent
-        self._set_gr_progress(0.5, "gpt inference latents...")
-        all_latents = []
-        for i in range(batch_codes.shape[0]):
-            codes = batch_codes[i] # [x]
-            codes = codes[codes != self.cfg.gpt.stop_mel_token]
-            codes, _ = torch.unique_consecutive(codes, return_inverse=True)
-            codes = codes.unsqueeze(0) # [x] -> [1, x]
-            code_lens = torch.tensor([codes.shape[-1]], device=codes.device, dtype=codes.dtype)
-            codes, code_lens = self.remove_long_silence(codes, silent_token=52, max_consecutive=30)
-            text_tokens = all_text_tokens[i]
+            
+        # Sequential processing of bucketing data
+        all_batch_num = 0
+        all_batch_codes = []
+        for item_tokens in all_text_tokens:
+            batch_num = len(item_tokens)
+            batch_text_tokens = self.pad_tokens_cat(item_tokens)
+            batch_cond_mel_lengths = torch.cat([cond_mel_lengths] * batch_num, dim=0)
+            batch_auto_conditioning = torch.cat([auto_conditioning] * batch_num, dim=0)
+            all_batch_num += batch_num
+            
+            # gpt speech
+            self._set_gr_progress(0.2, "gpt inference speech...")
             m_start_time = time.perf_counter()
             with torch.no_grad():
                 with torch.amp.autocast(self.device, enabled=self.dtype is not None, dtype=self.dtype):
-                    latent = \
-                        self.gpt(auto_conditioning, text_tokens,
-                                    torch.tensor([text_tokens.shape[-1]], device=text_tokens.device), codes,
-                                    code_lens*self.gpt.mel_length_compression,
-                                    cond_mel_lengths=torch.tensor([auto_conditioning.shape[-1]], device=text_tokens.device),
-                                    return_latent=True, clip_inputs=False)
-                    gpt_forward_time += time.perf_counter() - m_start_time
-                    all_latents.append(latent)
+                    temp_codes = self.gpt.inference_speech(batch_auto_conditioning, batch_text_tokens,
+                                        cond_mel_lengths=batch_cond_mel_lengths,
+                                        # text_lengths=text_len,
+                                        do_sample=True,
+                                        top_p=top_p,
+                                        top_k=top_k,
+                                        temperature=temperature,
+                                        num_return_sequences=autoregressive_batch_size,
+                                        length_penalty=length_penalty,
+                                        num_beams=num_beams,
+                                        repetition_penalty=repetition_penalty,
+                                        max_generate_length=max_mel_tokens)
+                    all_batch_codes.append(temp_codes)
+            gpt_gen_time += time.perf_counter() - m_start_time
+        
+        
+        # gpt latent
+        self._set_gr_progress(0.5, "gpt inference latents...")
+        all_idxs = []
+        all_latents = []
+        for batch_codes, batch_tokens, batch_sentences in zip(all_batch_codes, all_text_tokens, all_sentences):
+            for i in range(batch_codes.shape[0]):
+                codes = batch_codes[i] # [x]
+                codes = codes[codes != self.cfg.gpt.stop_mel_token]
+                codes, _ = torch.unique_consecutive(codes, return_inverse=True)
+                codes = codes.unsqueeze(0) # [x] -> [1, x]
+                code_lens = torch.tensor([codes.shape[-1]], device=codes.device, dtype=codes.dtype)
+                codes, code_lens = self.remove_long_silence(codes, silent_token=52, max_consecutive=30)
+                text_tokens = batch_tokens[i]
+                all_idxs.append(batch_sentences[i]["idx"])
+                m_start_time = time.perf_counter()
+                with torch.no_grad():
+                    with torch.amp.autocast(self.device, enabled=self.dtype is not None, dtype=self.dtype):
+                        latent = \
+                            self.gpt(auto_conditioning, text_tokens,
+                                        torch.tensor([text_tokens.shape[-1]], device=text_tokens.device), codes,
+                                        code_lens*self.gpt.mel_length_compression,
+                                        cond_mel_lengths=torch.tensor([auto_conditioning.shape[-1]], device=text_tokens.device),
+                                        return_latent=True, clip_inputs=False)
+                        gpt_forward_time += time.perf_counter() - m_start_time
+                        all_latents.append(latent)
+                        
         
         # bigvgan chunk
         chunk_size = 2      
+        all_latents = [all_latents[all_idxs.index(i)] for i in range(len(all_latents))]
         chunk_latents = [all_latents[i:i + chunk_size] for i in range(0, len(all_latents), chunk_size)]
         chunk_length = len(chunk_latents)
         latent_length = len(all_latents)
@@ -389,7 +418,7 @@ class IndexTTS:
         print(f">> Total fast inference time: {end_time - start_time:.2f} seconds")
         print(f">> Generated audio length: {wav_length:.2f} seconds")
         print(f">> [fast] bigvgan chunk_length: {chunk_length}")
-        print(f">> [fast] batch_num: {batch_num}")
+        print(f">> [fast] batch_num: {all_batch_num} bucket_enable: {bucket_enable}")
         print(f">> [fast] RTF: {(end_time - start_time) / wav_length:.4f}")
 
         # save audio


### PR DESCRIPTION
【问题描述】当输入某些长分句时，存在（漏句/丢句/音频空白）等异常情况。复现过程如下：

【复现过程1】使用（中文）文本进行测试，首句丢失： ”亲爱的伙伴们，大家好！“。
```
亲爱的伙伴们，大家好！每一次的努力都是为了更好的未来，要善于从失败中汲取经验，让我们一起勇敢前行,迈向更加美好的明天！
```

【复现过程2】使用（英文）文本进行测试，句尾丢失： ”Thank you!“。
```
The weather is really nice today, perfect for studying at home.Thank you!
```

---

【问题修复】经过对 `gpt.inference_speech` 结果反复检查，发现其 tokens 在某些情况下异常终止。我对此进行了修复，确保其不会中断。
经过修复，以上（中/英）"问题"文本均可完整推理输出。

【结果验证】更新此 PR 代码后，用相同文本进行推理，输出音频完整，再无漏丢句发生。
```
亲爱的伙伴们，大家好！每一次的努力都是为了更好的未来，要善于从失败中汲取经验，让我们一起勇敢前行,迈向更加美好的明天！
```
```
The weather is really nice today, perfect for studying at home.Thank you!
```
【超长多句文本验证】批次推理，无漏丢句发生。
```
叶远随口答应一声，一定帮忙云云。
教授看叶远的样子也知道，这事情多半是黄了。
谁得到这样的东西也不会轻易贡献出来，这是很大的一笔财富。
叶远回来后，又自己做了几次试验，发现空间湖水对一些外伤也有很大的帮助。
找来一只断了腿的兔子，喝下空间湖水，一天时间，兔子就完全好了。
还想多做几次试验，可是身边没有试验的对象，就先放到一边，了解空间湖水可以饮用，而且对人有利，这些就足够了。
感谢您的收听，下期再见！
```

```
批次分桶功能：关 
bucket_enable = False

>> Reference audio length: 7.90 seconds
>> gpt_gen_time: 7.87 seconds
>> gpt_forward_time: 0.23 seconds
>> bigvgan_time: 0.37 seconds
>> Total fast inference time: 8.53 seconds
>> Generated audio length: 45.61 seconds
>> [fast] RTF: 0.1869
```

【新增数据批次分桶机制】有效提升批次推理稳定性：（ 默认：已开启 True ）
> 可有效避免超长句与超短句进行批次，对提升 `gpt.inference_speech` 预测稳定性，证明效果显著。
> 分桶机制对 RTF 的影响，浮动参考值约 +~ 0.0167 左右。（不同长度的句子批次浮动有所不同）
```
批次分桶功能：开 
bucket_enable = True

>> [fast] RTF: 0.2036
```
---


👉️ 小提示：您需要在 webui 中，切换到【批次推理】`infer_fast` 模式进行复现和测试。
![image](https://github.com/user-attachments/assets/0ca67668-6234-42d8-8251-d8f18062da6f)
