### PR TITLE
单句推理：RTF 性能提速小优化 ~

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__
 *.egg-info
 *.DS_Store
 .idea/
+.vscode/
 checkpoints/*.pth
 checkpoints/*.vocab
 checkpoints/*.model

--- a/checkpoints/config.yaml
+++ b/checkpoints/config.yaml
@@ -19,6 +19,7 @@ gpt:
     use_mel_codes_as_input: true
     mel_length_compression: 1024
     layers: 20
+    activation_function: "gelu_pytorch_tanh"
     number_text_tokens: 12000
     number_mel_codes: 8194
     start_mel_token: 8192

--- a/indextts/infer.py
+++ b/indextts/infer.py
@@ -11,6 +11,10 @@ from torch.nn.utils.rnn import pad_sequence
 from omegaconf import OmegaConf
 from tqdm import tqdm
 
+import warnings
+warnings.filterwarnings("ignore", category=FutureWarning)
+warnings.filterwarnings("ignore", category=UserWarning)
+
 from indextts.BigVGAN.models import BigVGAN as Generator
 from indextts.gpt.model import UnifiedVoice
 from indextts.utils.checkpoint import load_checkpoint


### PR DESCRIPTION
【提速原理】通过调整模型的默认激活函数，来进一步提升神经网络的基础推理性能。
经过多轮测试，普通模式和批次模式， RTF 值均下降明显（参考值约 >= 5 % ）。

本次 checkpoints\config.yaml 新增的选项如下，（您或可将其直接注释，以恢复原始配置）：
```
activation_function: "gelu_pytorch_tanh"
```


如需恢复之前旧配置，只需将其注释即可测试：
```
# activation_function: "gelu_pytorch_tanh"
```


本次推理测试代码：
```
prompt_wav="tests/sample_prompt.wav"
tts = IndexTTS(cfg_path="checkpoints/config.yaml", model_dir="checkpoints", is_fp16=True, use_cuda_kernel=False)
（1）普通推理 tts.infer 
（2）批次推理 tts.infer_fast 
```
---

普通推理 `tts.infer` ，单句单行输入文本测试：
```
每一次的努力都是为了更好的未来,要善于从失败中汲取经验,让我们一起勇敢前行,迈向更加美好的明天!
```


【优化前， 注释 activation_function】普通推理-单行单句
```
# activation_function: "gelu_pytorch_tanh"  # 注释掉，代表使用旧版

normalized text:每一次的努力都是为了更好的未来,要善于从失败中汲取经验,让我们一起勇敢前行,迈向更加美好的明天!
device='cuda:0', dtype=torch.float16)
>> Reference audio length: 5.45 seconds
>> gpt_gen_time: 4.18 seconds
>> gpt_forward_time: 0.03 seconds
>> bigvgan_time: 0.27 seconds
>> Total inference time: 4.49 seconds
>> Generated audio length: 8.79 seconds
>> RTF: 0.5113
```

【优化后， 启用 activation_function】普通推理-单行单句，其 RTF 值显著下降：5 % ！
```
activation_function: "gelu_pytorch_tanh" # 启用配置

normalized text:每一次的努力都是为了更好的未来,要善于从失败中汲取经验,让我们一起勇敢前行,迈向更加美好的明天!
device='cuda:0', dtype=torch.float16)
>> Reference audio length: 5.45 seconds
>> gpt_gen_time: 3.69 seconds
>> gpt_forward_time: 0.02 seconds
>> bigvgan_time: 0.22 seconds
>> Total inference time: 3.96 seconds
>> Generated audio length: 8.70 seconds
>> RTF: 0.4544
```

---


批次推理  `tts.infer_fast`  多行多句，因基础速度提升后，对批次速度也有显著提升。

以下多行多句测试文本输入：
```
叶远随口答应一声，一定帮忙云云。
教授看叶远的样子也知道，这事情多半是黄了。
谁得到这样的东西也不会轻易贡献出来，这是很大的一笔财富。
叶远回来后，又自己做了几次试验，发现空间湖水对一些外伤也有很大的帮助。
找来一只断了腿的兔子，喝下空间湖水，一天时间，兔子就完全好了。
还想多做几次试验，可是身边没有试验的对象，就先放到一边，了解空间湖水可以饮用，而且对人有利，这些就足够了。
感谢您的收听，下期再见！
```


【优化前， 注释 activation_function】批次推理-多行多句。
```
# activation_function: "gelu_pytorch_tanh"  # 注释掉，代表使用旧版

>> Reference audio length: 5.45 seconds
>> gpt_gen_time: 6.94 seconds
>> gpt_forward_time: 0.17 seconds
>> bigvgan_time: 0.67 seconds
>> Total fast inference time: 7.80 seconds
>> Generated audio length: 35.80 seconds
>> [fast] RTF: 0.2179
```

【优化后， 启用 activation_function】批次推理-多行多句，其 RTF 值显著下降，提速约 1.0 秒左右。
```
activation_function: "gelu_pytorch_tanh" # 启用配置

>> gpt_gen_time: 5.57 seconds
>> gpt_forward_time: 0.17 seconds
>> bigvgan_time: 0.66 seconds
>> Total fast inference time: 6.43 seconds
>> Generated audio length: 35.97 seconds
>> [fast] RTF: 0.1788
```

---

优化总结：经过调整新的模型激活函数，能有效提升【普通推理】和【批次推理】的 RTF 整体性能。
对于单行单句效果明显，推理基础等待时间，相比之前，可至少减少约 0.5~1.0s 秒左右！
