### PR TITLE
Fix: 修复split_sentences_by_token方法中可能出现的无限递归问题

### DIFF
--- a/indextts/utils/front.py
+++ b/indextts/utils/front.py
@@ -328,7 +328,7 @@ class TextTokenizer:
 
     @staticmethod
     def split_sentences_by_token(
-        tokenized_str: List[str], split_tokens: List[str], max_tokens_per_sentence: int
+        tokenized_str: List[str], split_tokens: List[str], max_tokens_per_sentence: int, allow_recursive: bool = True
     ) -> List[List[str]]:
         """
         将tokenize后的结果按特定token进一步分割
@@ -355,15 +355,21 @@ class TextTokenizer:
                     sentences.append(current_sentence)
                 else:
                     # 如果当前tokens的长度超过最大限制
-                    if "," in current_sentence or "▁," in current_sentence: 
+                    if allow_recursive and ("," in current_sentence or "▁," in current_sentence):
                         # 如果当前tokens中有,，则按,分割
                         sub_sentences = TextTokenizer.split_sentences_by_token(
-                            current_sentence, [",", "▁,"], max_tokens_per_sentence=max_tokens_per_sentence
+                            current_sentence,
+                            [",", "▁,"],
+                            max_tokens_per_sentence=max_tokens_per_sentence,
+                            allow_recursive=False
                         )
-                    elif "-" in current_sentence:
+                    elif allow_recursive and "-" in current_sentence:
                         # 没有,，则按-分割
                         sub_sentences = TextTokenizer.split_sentences_by_token(
-                            current_sentence, ["-"], max_tokens_per_sentence=max_tokens_per_sentence
+                            current_sentence,
+                            ["-"],
+                            max_tokens_per_sentence=max_tokens_per_sentence,
+                            allow_recursive=False
                         )
                     else:
                         # 按照长度分割


### PR DESCRIPTION
修复split_sentences_by_token方法中的无限递归问题

在split_sentences_by_token方法中，当句子超过max_tokens_per_sentence时，
会根据","或"-"进行分割。但如果分割后的部分仍然过长，
原代码会递归调用自身，这可能导致无限递归和堆栈溢出错误。

此PR通过添加allow_recursive参数解决了这个问题，
在递归调用时将其设为false，确保最多只递归一层，
避免潜在的堆栈溢出问题。