### PR TITLE
speaker mel cache

### DIFF
--- a/indextts/infer.py
+++ b/indextts/infer.py
@@ -11,6 +11,7 @@ import torchaudio
 from torch.nn.utils.rnn import pad_sequence
 from omegaconf import OmegaConf
 from tqdm import tqdm
+import uuid
 
 import warnings
 
@@ -125,6 +126,7 @@ class IndexTTS:
         self.cache_cond_mel = None
         # 进度引用显示（可选）
         self.gr_progress = None
+        self.speaker_mel = {}
 
     def remove_long_silence(self, codes: torch.Tensor, silent_token=52, max_consecutive=30):
         code_lens = []
@@ -402,32 +404,52 @@ class IndexTTS:
             wav_data = wav_data.numpy().T
             return (sampling_rate, wav_data)
 
+    # 将音频文件生成的cond_mel缓存，并返回相应的speaker_id
+    def speaker_cache(self, audio_prompt, verbose=False):
+        audio, sr = torchaudio.load(audio_prompt)
+        audio = torch.mean(audio, dim=0, keepdim=True)
+        if audio.shape[0] > 1:
+            audio = audio[0].unsqueeze(0)
+        audio = torchaudio.transforms.Resample(sr, 24000)(audio)
+        cond_mel = MelSpectrogramFeatures()(audio).to(self.device)
+        if verbose:
+            print(f"cond_mel shape: {cond_mel.shape}", "dtype:", cond_mel.dtype)
+        speaker_id = str(uuid.uuid4())
+        self.speaker_mel[speaker_id] = cond_mel 
+        return speaker_id
+
+
     # 原始推理模式
-    def infer(self, audio_prompt, text, output_path, verbose=False):
+    def infer(self, audio_prompt, text, output_path, verbose=False, speaker_id=None):
         print(">> start inference...")
         self._set_gr_progress(0, "start inference...")
         if verbose:
             print(f"origin text:{text}")
         start_time = time.perf_counter()
 
-        # 如果参考音频改变了，才需要重新生成 cond_mel, 提升速度
-        if self.cache_cond_mel is None or self.cache_audio_prompt != audio_prompt:
-            audio, sr = torchaudio.load(audio_prompt)
-            audio = torch.mean(audio, dim=0, keepdim=True)
-            if audio.shape[0] > 1:
-                audio = audio[0].unsqueeze(0)
-            audio = torchaudio.transforms.Resample(sr, 24000)(audio)
-            cond_mel = MelSpectrogramFeatures()(audio).to(self.device)
-            cond_mel_frame = cond_mel.shape[-1]
-            if verbose:
-                print(f"cond_mel shape: {cond_mel.shape}", "dtype:", cond_mel.dtype)
+        # 如果当前 speaker_id 缓存过，则直接使用该 speaker_id 对应的 cond_mel
+        if speaker_id is None:
+            # 如果参考音频改变了，才需要重新生成 cond_mel, 提升速度
+            if self.cache_cond_mel is None or self.cache_audio_prompt != audio_prompt:
+                audio, sr = torchaudio.load(audio_prompt)
+                audio = torch.mean(audio, dim=0, keepdim=True)
+                if audio.shape[0] > 1:
+                    audio = audio[0].unsqueeze(0)
+                audio = torchaudio.transforms.Resample(sr, 24000)(audio)
+                cond_mel = MelSpectrogramFeatures()(audio).to(self.device)
+                cond_mel_frame = cond_mel.shape[-1]
+                if verbose:
+                    print(f"cond_mel shape: {cond_mel.shape}", "dtype:", cond_mel.dtype)
 
-            self.cache_audio_prompt = audio_prompt
-            self.cache_cond_mel = cond_mel
+                self.cache_audio_prompt = audio_prompt
+                self.cache_cond_mel = cond_mel
+            else:
+                cond_mel = self.cache_cond_mel
+                cond_mel_frame = cond_mel.shape[-1]
+                pass
         else:
-            cond_mel = self.cache_cond_mel
+            cond_mel = self.speaker_mel[speaker_id]
             cond_mel_frame = cond_mel.shape[-1]
-            pass
 
         auto_conditioning = cond_mel
         text_tokens_list = self.tokenizer.tokenize(text)

--- a/tests/regression_test.py
+++ b/tests/regression_test.py
@@ -40,3 +40,8 @@ if __name__ == "__main__":
 讲述了由莱昂纳多·迪卡普里奥扮演的造梦师，带领特工团队进入他人梦境，从他人的潜意识中盗取机密，并重塑他人梦境的故事。
 """.replace("\n", "")
     tts.infer_fast(audio_prompt=prompt_wav, text=text, output_path=f"outputs/{text[:20]}.wav", verbose=True)
+    # speaker mel 缓存测试
+    text="大家好，我现在正在bilibili 体验 ai 科技，说实话，来之前我绝对想不到！AI技术已经发展到这样匪夷所思的地步了！比如说，现在正在说话的其实是B站为我现场复刻的数字分身，简直就是平行宇宙的另一个我了。如果大家也想体验更多深入的AIGC功能，可以访问 bilibili studio，相信我，你们也会吃惊的。"
+    speaker_id = tts.speaker_cache(prompt_wav, verbose=True)
+    print("speaker id: ", tts.speaker_mel.keys())
+    tts.infer(audio_prompt="", text=text, output_path=f"outputs/{text[:20]}.wav", verbose=True, speaker_id=speaker_id)


### PR DESCRIPTION
建立一个speaker_mel字典，提前计算缓存音频的梅尔谱(可缓存多个)，返回相应的 speaker_id。以speaker_id替代audio_prompt作为infer()的输入。可以提高频繁切换参考音频时的推理速度。