### PR TITLE
adding support to specify GPU Device by ID through CLI

### DIFF
--- a/indextts/infer.py
+++ b/indextts/infer.py
@@ -41,6 +41,8 @@ class IndexTTS:
             self.device = device
             self.is_fp16 = False if device == "cpu" else is_fp16
             self.use_cuda_kernel = use_cuda_kernel is not None and use_cuda_kernel and device.startswith("cuda")
+            if device.startswith("cuda"):
+                torch.cuda.set_device(device)
         elif torch.cuda.is_available():
             self.device = "cuda:0"
             self.is_fp16 = is_fp16


### PR DESCRIPTION
This will fix errors returned when specifying a device other than cuda:0 through cli on systems with more than 1 GPU

```root@625c7faf18e8:/app/index-tts# PYTHONPATH=. python3 indextts/cli.py -v test_data/input.wav "There is a vehicle arriving in dock number 7?" --force -d cuda:1
>> GPT weights restored from: checkpoints/gpt.pth
[2025-05-11 00:05:17,771] [INFO] [real_accelerator.py:239:get_accelerator] Setting ds_accelerator to cuda (auto detect)
[2025-05-11 00:05:18,917] [INFO] [logging.py:107:log_dist] [Rank -1] DeepSpeed info: version=0.16.7, git-hash=unknown, git-branch=unknown
[2025-05-11 00:05:18,918] [WARNING] [config_utils.py:70:_process_deprecated_field] Config parameter mp_size is deprecated use tensor_parallel.tp_size instead
[2025-05-11 00:05:18,918] [INFO] [logging.py:107:log_dist] [Rank -1] quantize_bits = 8 mlp_extra_grouping = False, quantize_groups = 1
Removing weight norm...
>> bigvgan weights restored from: checkpoints/bigvgan_generator.pth
2025-05-11 00:05:20,897 WETEXT INFO found existing fst: /usr/local/lib/python3.10/dist-packages/tn/zh_tn_tagger.fst
2025-05-11 00:05:20,897 WETEXT INFO                     /usr/local/lib/python3.10/dist-packages/tn/zh_tn_verbalizer.fst
2025-05-11 00:05:20,897 WETEXT INFO skip building fst for zh_normalizer ...
2025-05-11 00:05:21,167 WETEXT INFO found existing fst: /usr/local/lib/python3.10/dist-packages/tn/en_tn_tagger.fst
2025-05-11 00:05:21,167 WETEXT INFO                     /usr/local/lib/python3.10/dist-packages/tn/en_tn_verbalizer.fst
2025-05-11 00:05:21,167 WETEXT INFO skip building fst for en_normalizer ...
>> TextNormalizer loaded
2025-05-11 00:05:21,842 WETEXT INFO found existing fst: /usr/local/lib/python3.10/dist-packages/tn/zh_tn_tagger.fst
2025-05-11 00:05:21,842 WETEXT INFO found existing fst: /usr/local/lib/python3.10/dist-packages/tn/zh_tn_tagger.fst
2025-05-11 00:05:21,842 WETEXT INFO                     /usr/local/lib/python3.10/dist-packages/tn/zh_tn_verbalizer.fst
2025-05-11 00:05:21,842 WETEXT INFO                     /usr/local/lib/python3.10/dist-packages/tn/zh_tn_verbalizer.fst
2025-05-11 00:05:21,843 WETEXT INFO skip building fst for zh_normalizer ...
2025-05-11 00:05:21,843 WETEXT INFO skip building fst for zh_normalizer ...
2025-05-11 00:05:22,358 WETEXT INFO found existing fst: /usr/local/lib/python3.10/dist-packages/tn/en_tn_tagger.fst
2025-05-11 00:05:22,358 WETEXT INFO found existing fst: /usr/local/lib/python3.10/dist-packages/tn/en_tn_tagger.fst
2025-05-11 00:05:22,358 WETEXT INFO                     /usr/local/lib/python3.10/dist-packages/tn/en_tn_verbalizer.fst
2025-05-11 00:05:22,358 WETEXT INFO                     /usr/local/lib/python3.10/dist-packages/tn/en_tn_verbalizer.fst
2025-05-11 00:05:22,358 WETEXT INFO skip building fst for en_normalizer ...
2025-05-11 00:05:22,358 WETEXT INFO skip building fst for en_normalizer ...
>> bpe model loaded from: checkpoints/bpe.model
>> start inference...
Traceback (most recent call last):
  File "/app/index-tts/indextts/cli.py", line 62, in <module>
    main()
  File "/app/index-tts/indextts/cli.py", line 59, in main
    tts.infer(audio_prompt=args.voice, text=args.text.strip(), output_path=output_path)
  File "/app/index-tts/indextts/infer.py", line 476, in infer
    codes = self.gpt.inference_speech(auto_conditioning, text_tokens,
  File "/app/index-tts/indextts/gpt/model.py", line 622, in inference_speech
    gen = self.inference_model.generate(inputs, bos_token_id=self.start_mel_token, pad_token_id=self.stop_mel_token,
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/transformers/generation/utils.py", line 1834, in generate
    return self.beam_sample(
  File "/usr/local/lib/python3.10/dist-packages/transformers/generation/utils.py", line 3515, in beam_sample
    outputs = self(
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
  File "/app/index-tts/indextts/gpt/model.py", line 142, in forward
    text_emb = self.embeddings(text_inputs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/sparse.py", line 190, in forward
    return F.embedding(
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/functional.py", line 2551, in embedding
    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cuda:1! (when checking argument for argument index in method wrapper_CUDA__index_select)```