### PR TITLE
提升了输出音频的采样率

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -3,6 +3,7 @@ import os
 import sys
 import threading
 import time
+import pandas as pd
 
 import warnings
 warnings.filterwarnings("ignore", category=FutureWarning)

--- a/webui.py
+++ b/webui.py
@@ -4,6 +4,8 @@ import sys
 import threading
 import time
 import pandas as pd
+import librosa
+import soundfile as sf
 
 import warnings
 warnings.filterwarnings("ignore", category=FutureWarning)
@@ -90,7 +92,15 @@ def gen_single(prompt, text, infer_mode, max_text_tokens_per_sentence=120, sente
             max_text_tokens_per_sentence=int(max_text_tokens_per_sentence),
             sentences_bucket_max_size=(sentences_bucket_max_size),
             **kwargs)
-    return gr.update(value=output,visible=True)
+    
+    # 提升采样率，防闷
+    original_sr = 24000
+    target_sr = 48000
+    audio, _ = librosa.load(output_path, sr=original_sr)
+    high_res_audio = librosa.resample(audio, orig_sr=original_sr, target_sr=target_sr)
+    sf.write(output_path, high_res_audio, target_sr)
+
+    return gr.update(value=output_path, visible=True)
 
 def update_prompt_audio():
     update_button = gr.update(interactive=True)


### PR DESCRIPTION
## 新增特性
将WebUI生成的音频采样率从24kHz**重采样到48kHz**，能够在听感上**显著去除音频的“闷感”**。使用librosa和soundfile实现（已在requirements.txt中），无需引入新的库。**此改动对推理性能几乎无影响。**

### 测试条件
- **参考音频**: 相同  
- **文本**: 相同  
- **推理方式**: 批量推理  
- **显卡**: RTX 2080 Ti 22G

### 测试结果
| 实验组   | 第一次 | 第二次 | 第三次 | 第四次 | 第五次 | 第六次 | 推理平均用时|
|----------|--------|--------|--------|--------|--------|--------|----------|
| 改动前   | 9.37s   | 8.46s   | 8.39s   | 9.52s   | 9.14s   | 8.58s   | **8.91s** |
| 改动后   | 9.21s   | 9.28s   | 8.93s   | 8.84s   | 8.97s   | 8.72s   | **8.99s** |

## 错误修复
导入了缺失的pandas，修复了`NameError: name 'pd' is not defined`