### PR TITLE
fix: 修复样本音频太长报错的问题，对音频进行裁切。

### DIFF
--- a/indextts/infer.py
+++ b/indextts/infer.py
@@ -299,6 +299,15 @@ class IndexTTS:
             if audio.shape[0] > 1:
                 audio = audio[0].unsqueeze(0)
             audio = torchaudio.transforms.Resample(sr, 24000)(audio)
+
+            max_audio_length_seconds = 50  
+            max_audio_samples = int(max_audio_length_seconds * 24000)
+            
+            if audio.shape[1] > max_audio_samples:
+                if verbose:
+                    print(f"Audio too long ({audio.shape[1]} samples), truncating to {max_audio_samples} samples")
+                audio = audio[:, :max_audio_samples]
+
             cond_mel = MelSpectrogramFeatures()(audio).to(self.device)
             cond_mel_frame = cond_mel.shape[-1]
             if verbose:


### PR DESCRIPTION
限制音频长度以避免位置编码超出限制
计算最大允许的音频长度（以秒为单位）
位置编码最大长度5000帧，mel频谱的hop_length=256，采样率24000
 最大音频长度 = 5000 * 256 / 24000 ≈ 53.3秒