### PR TITLE
feat: added support for target audio duration via speech_length parameter

### DIFF
--- a/indextts/infer_v2.py
+++ b/indextts/infer_v2.py
@@ -636,8 +636,8 @@ class IndexTTS2:
                             print(f"!!! Falling back to default duration logic for {seg_idx} segment")
                         else:
                             duration_ratio = len_current / len_total
-                            print(f">> Generating segment {seg_idx}: {duration_ratio*100:.2f}% of total audio duration ({int(target_chunk_ms)}ms)")
                             target_chunk_ms = speech_length * duration_ratio
+                            print(f">> Generating segment {seg_idx}: {duration_ratio*100:.2f}% of total audio duration ({int(target_chunk_ms)}ms)")
                             len_tensor = torch.LongTensor([int(speech_length*duration_ratio)])
                             len_tensor = len_tensor.to(self.device)
                             target_lengths = torch.clamp((len_tensor/frame_duration).long(), min=1)


### PR DESCRIPTION
This PR adds speech_length parameter that allows to specify desired duration in ms for generated audio.
For example, it could be useful for translating audio/video materials according to existing timestamps.
It allows to automatically match duration of generated audio to existing time slots of the original content.

The generated audio doesn't perfectly match target duration but difference isn't very big for short audio fragments.