### PR TITLE
Add setting of hf_hub_cache env var through OS

### DIFF
--- a/indextts/infer.py
+++ b/indextts/infer.py
@@ -1,6 +1,9 @@
 import os
 
-os.environ['HF_HUB_CACHE'] = './checkpoints/hf_cache'
+from .utils.hf_cache import set_hf_env
+
+set_hf_env()
+
 import time
 from subprocess import CalledProcessError
 from typing import Dict, List

--- a/indextts/infer_v2.py
+++ b/indextts/infer_v2.py
@@ -1,7 +1,11 @@
 import os
+
+from .utils.hf_cache import set_hf_env
+
+set_hf_env()
+
 from subprocess import CalledProcessError
 
-os.environ['HF_HUB_CACHE'] = './checkpoints/hf_cache'
 import json
 import re
 import time

--- a/indextts/utils/hf_cache.py
+++ b/indextts/utils/hf_cache.py
@@ -1,0 +1,15 @@
+"""Helper to configure a project-local Hugging Face Hub cache.
+If HF_HUB_CACHE is not set in the environment, this module sets it to the
+`/checkpoints/hf_cache` of the repo directory.
+"""
+
+import os
+
+
+def set_hf_env() -> None:
+    if "HF_HUB_CACHE" not in os.environ:
+        CURRENT_FILE_DIR = os.path.dirname(os.path.abspath(__file__))
+        HF_HUB_CACHE_DIR = os.path.abspath(
+            os.path.join(CURRENT_FILE_DIR, "..", "checkpoints", "hf_cache")
+        )
+        os.environ["HF_HUB_CACHE"] = HF_HUB_CACHE_DIR


### PR DESCRIPTION
## Context

This PR enables the setting and usage of the HF_HUB_CACHE env var to define where hf hub stores its cache.

The issue is that when it's run as a submodule, `checkpoints/hf_cache` will be at the root directory of the main project.
This results in an unclear and unorganized folder structure that doers not match what the README.md describes.

Expected:
```
app
├── index-tts / checkpoints / hf_cache
└── api/
```

Actual:
```
app
├── checkpoints/hf_cache
├── index-tts/
└── api/
```


## Description

To resolve the issue, we create a new helper file to set the `HF_HUB_CACHE` env var if it's defined or defaults to the index-tts' project specific directory.

End Result after changes:
```
app
├── index-tts / checkpoints / hf_cache
└── api/
```







