### PR TITLE
Fix bug of always using do_sample=True

### DIFF
--- a/indextts/infer_v2.py
+++ b/indextts/infer_v2.py
@@ -562,7 +562,7 @@ class IndexTTS2:
                         cond_lengths=torch.tensor([spk_cond_emb.shape[-1]], device=text_tokens.device),
                         emo_cond_lengths=torch.tensor([emo_cond_emb.shape[-1]], device=text_tokens.device),
                         emo_vec=emovec,
-                        do_sample=True,
+                        do_sample=do_sample,
                         top_p=top_p,
                         top_k=top_k,
                         temperature=temperature,


### PR DESCRIPTION
So that users can manually pass do_sample=True for deterministic decoding. Otherwise, the do_sample argument is taken out but never used.