### PR TITLE
Fix: remove redundant code_lens initialization

### DIFF
--- a/indextts/infer_v2.py
+++ b/indextts/infer_v2.py
@@ -589,8 +589,6 @@ class IndexTTS2:
                         category=RuntimeWarning
                     )
                     has_warned = True
-
-                code_lens = torch.tensor([codes.shape[-1]], device=codes.device, dtype=codes.dtype)
                 #                 if verbose:
                 #                     print(codes, type(codes))
                 #                     print(f"codes shape: {codes.shape}, codes type: {codes.dtype}")


### PR DESCRIPTION
This PR removes the following line of code: code_lens = torch.tensor([codes.shape[-1]], device=codes.device, dtype=codes.dtype)

Reasons for removal:

1.Dead Code: This variable is immediately overwritten by code_lens = [] a few lines later, making it completely non-functional.

2.Type Safety Risk: The line uses dtype=codes.dtype. In many TTS tasks, codes is a Float or Half tensor. However, code_lens must be a Long tensor for indexing or masking operations. If this "dead code" were ever utilized, it would likely trigger a RuntimeError due to the incorrect data type.