### PR TITLE
Improve sentence accumulation in front.py

### DIFF
--- a/indextts/utils/front.py
+++ b/indextts/utils/front.py
@@ -565,9 +565,14 @@ class TextTokenizer:
                     "Maybe unexpected behavior",
                     RuntimeWarning,
                 )
-            segments.extend(sub_segments)
-            current_segment = []
-            current_segment_tokens_len = 0
+            if len(sub_sentences) > 0:
+                sentences.extend(sub_sentences[:-1])
+                # 将最后一个片段作为新的当前句子继续累积，否则会被单独作为一个片段（很可能是不完整的）
+                current_sentence = sub_sentences[-1]
+                current_sentence_tokens_len = len(current_sentence)
+            else:
+                current_sentence = []
+                current_sentence_tokens_len = 0
         if current_segment_tokens_len > 0:
             assert current_segment_tokens_len <= max_text_tokens_per_segment
             segments.append(current_segment)


### PR DESCRIPTION
修复了在一定情况下会将完整句子拦腰截断的bug，举个例子：

```bash
from indextts.utils.front import TextTokenizer

text = "在真正的日本剑道中,格斗过程极其短暂,常常短至半秒,最长也不超过两秒,利剑相击的转瞬间,已有一方倒在血泊中。"
text = [c for c in text]

punctuation_marks_tokens = [
    ".",
    "!",
    "?",
    "▁.",
    # "▁!", # unk
    "▁?",
    "▁...", # ellipsis
]
sentences = TextTokenizer.split_sentences_by_token(text, punctuation_marks_tokens, 27)
for sentence in sentences:
    print(len(sentence), sentence)
```

输出如下：
26 ['在', '真', '正', '的', '日', '本', '剑', '道', '中', ',', '格', '斗', '过', '程', '极', '其', '短', '暂', ',', '常', '常', '短', '至', '半', '秒', ',']
2 ['最', '长']
26 ['也', '不', '超', '过', '两', '秒', '，', '利', '剑', '相', '击', '的', '转', '瞬', '间', '，', '已', '有', '一', '方', '倒', '在', '血', '泊', '中', '。']

其中 ['最', '长'] 被单独切分为一段，会导致最终语音中存在不自然的停顿

更新的代码解决了这个问题