### PR TITLE
fix: coerce QwenEmotion scores to float before clamp_score comparison

### DIFF
--- a/indextts/infer_v2.py
+++ b/indextts/infer_v2.py
@@ -755,6 +755,10 @@ class QwenEmotion:
         self.min_score = 0.0
 
     def clamp_score(self, value):
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            value = 0.0
         return max(self.min_score, min(self.max_score, value))
 
     def convert(self, content):


### PR DESCRIPTION
QwenEmotion.inference() parses JSON from the Qwen model, which can return stringified numbers (e.g. '0.5' instead of 0.5). When passed to clamp_score(), min(float, str) raises TypeError: '<' not supported between instances of 'str' and 'float'.

Add float() coercion at the top of clamp_score() with a safe fallback to 0.0 for unconvertible values.