### PR TITLE
webui: require speaker target for speaker-linked emotion references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ desktop.ini
 /cache/
 /checkpoints/*
 !/checkpoints/*.yaml
+/logs/
 /outputs/

--- a/README.md
+++ b/README.md
@@ -313,6 +313,26 @@ text = "Translate for me, what is a surprise!"
 tts.infer(spk_audio_prompt='examples/voice_01.wav', text=text, output_path="gen.wav", verbose=True)
 ```
 
+You can also pass multiple speaker or emotion references as a list or tuple,
+and optionally provide weights via `spk_audio_weights` / `emo_audio_weights`.
+Weights are normalized automatically. If omitted, equal weighting is applied
+across all references:
+
+```python
+from indextts.infer_v2 import IndexTTS2
+tts = IndexTTS2(cfg_path="checkpoints/config.yaml", model_dir="checkpoints", use_fp16=False, use_cuda_kernel=False, use_deepspeed=False)
+text = "Blend timbre from several references while keeping a stable output."
+tts.infer(
+    spk_audio_prompt=["examples/voice_01.wav", "examples/voice_07.wav", "examples/voice_12.wav"],
+    spk_audio_weights=[0.5, 0.3, 0.2],
+    text=text,
+    output_path="gen.wav",
+    emo_audio_prompt=["examples/emo_sad.wav", "examples/emo_surprise.wav"],
+    emo_audio_weights=[2, 1],
+    verbose=True,
+)
+```
+
 2. Using a separate, emotional reference audio file to condition the speech synthesis:
 
 ```python

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -252,6 +252,25 @@ text = "Translate for me, what is a surprise!"
 tts.infer(spk_audio_prompt='examples/voice_01.wav', text=text, output_path="gen.wav", verbose=True)
 ```
 
+也可以一次传入多个音色参考或情感参考音频，并通过
+`spk_audio_weights` / `emo_audio_weights` 指定权重。权重会自动归一化；
+如果省略则默认等权融合：
+
+```python
+from indextts.infer_v2 import IndexTTS2
+tts = IndexTTS2(cfg_path="checkpoints/config.yaml", model_dir="checkpoints", use_fp16=False, use_cuda_kernel=False, use_deepspeed=False)
+text = "Blend timbre from several references while keeping a stable output."
+tts.infer(
+    spk_audio_prompt=["examples/voice_01.wav", "examples/voice_07.wav", "examples/voice_12.wav"],
+    spk_audio_weights=[0.5, 0.3, 0.2],
+    text=text,
+    output_path="gen.wav",
+    emo_audio_prompt=["examples/emo_sad.wav", "examples/emo_surprise.wav"],
+    emo_audio_weights=[2, 1],
+    verbose=True,
+)
+```
+
 2. 指定情感参考音频：
 
 ```python

--- a/indextts/emotion_reference_selection.py
+++ b/indextts/emotion_reference_selection.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import os
+from typing import Sequence
+
+from indextts.reference_conditioning import WeightedReference
+
+
+def normalize_weight_list(weights, label):
+    normalized = [float(weight) for weight in weights]
+    if any(weight < 0 for weight in normalized):
+        raise ValueError(f"{label} weights must be non-negative")
+    weight_sum = sum(normalized)
+    if weight_sum <= 0:
+        raise ValueError(f"{label} weights must sum to a value greater than 0")
+    return [weight / weight_sum for weight in normalized]
+
+
+def normalize_emotion_input_rows(emotion_references, default_text):
+    if emotion_references is None:
+        return None
+
+    if isinstance(emotion_references, dict):
+        raw_rows = [emotion_references]
+    elif isinstance(emotion_references, (list, tuple)):
+        raw_rows = list(emotion_references)
+    else:
+        raise TypeError("emotion_references must be a dict or a sequence of dicts")
+
+    normalized_rows = []
+    raw_weights = []
+    for index, raw_row in enumerate(raw_rows):
+        if not isinstance(raw_row, dict):
+            raise TypeError(f"emotion_references[{index}] must be a dict")
+
+        row_type = str(raw_row.get("type", "audio")).strip().lower()
+        weight = float(raw_row.get("weight", 1.0))
+        if row_type == "speaker":
+            normalized_row = {"type": "speaker"}
+            speaker_index = raw_row.get("speaker_index")
+            if speaker_index not in (None, ""):
+                try:
+                    normalized_row["speaker_index"] = int(speaker_index)
+                except (TypeError, ValueError) as exc:
+                    raise ValueError(
+                        f"emotion_references[{index}] speaker rows require an integer speaker_index"
+                    ) from exc
+            normalized_rows.append(normalized_row)
+        elif row_type == "audio":
+            path = raw_row.get("path") or raw_row.get("audio_path")
+            if path is None:
+                raise ValueError(f"emotion_references[{index}] audio rows require a path")
+            normalized_rows.append({"type": "audio", "path": os.path.abspath(os.fspath(path))})
+        elif row_type == "vector":
+            vector = raw_row.get("vector")
+            if not isinstance(vector, (list, tuple)) or len(vector) != 8:
+                raise ValueError(f"emotion_references[{index}] vector rows require an 8-d vector")
+            normalized_rows.append({"type": "vector", "vector": [float(value) for value in vector]})
+        elif row_type == "text":
+            text_value = raw_row.get("text")
+            if text_value is None:
+                text_value = default_text
+            text_value = str(text_value).strip()
+            if not text_value:
+                raise ValueError(f"emotion_references[{index}] text rows require non-empty text")
+            normalized_rows.append({"type": "text", "text": text_value})
+        else:
+            raise ValueError(f"Unsupported emotion reference type: {row_type}")
+
+        raw_weights.append(weight)
+
+    normalized_weights = normalize_weight_list(raw_weights, "emotion reference")
+    for row, weight in zip(normalized_rows, normalized_weights):
+        row["weight"] = weight
+    return normalized_rows
+
+
+def resolve_speaker_reference_index(row, speaker_reference_count):
+    if speaker_reference_count <= 0:
+        raise ValueError("Speaker-linked emotion rows require at least one active speaker reference")
+
+    speaker_index = row.get("speaker_index")
+    if speaker_index is None:
+        if speaker_reference_count == 1:
+            return 0
+        raise ValueError(
+            "Speaker-linked emotion rows require speaker_index when multiple speaker references are active"
+        )
+
+    try:
+        speaker_index = int(speaker_index)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Speaker-linked emotion rows require an integer speaker_index") from exc
+
+    if speaker_index < 0 or speaker_index >= speaker_reference_count:
+        raise ValueError(
+            f"speaker_index {speaker_index} is out of range for {speaker_reference_count} active speaker references"
+        )
+    return speaker_index
+
+
+def expand_audio_like_emotion_rows(
+    emotion_rows,
+    speaker_references: Sequence[WeightedReference],
+):
+    expanded_references = []
+
+    for row in emotion_rows:
+        if row["type"] == "speaker":
+            speaker_index = resolve_speaker_reference_index(row, len(speaker_references))
+            expanded_references.append(
+                WeightedReference(
+                    path=speaker_references[speaker_index].path,
+                    weight=row["weight"],
+                )
+            )
+        elif row["type"] == "audio":
+            expanded_references.append(WeightedReference(path=row["path"], weight=row["weight"]))
+
+    return expanded_references or None

--- a/indextts/gpt/model_v2.py
+++ b/indextts/gpt/model_v2.py
@@ -695,7 +695,7 @@ class UnifiedVoice(nn.Module):
         fake_inputs[:, -1] = self.start_mel_token
         return fake_inputs, batched_mel_emb, attention_mask
 
-    def inference_speech(self, speech_condition, text_inputs, emo_speech_condition=None, cond_lengths=None, emo_cond_lengths=None, emo_vec=None, use_speed=False, input_tokens=None, num_return_sequences=1,
+    def inference_speech(self, speech_condition, text_inputs, emo_speech_condition=None, cond_lengths=None, emo_cond_lengths=None, speech_conditioning_latent=None, emo_vec=None, use_speed=False, input_tokens=None, num_return_sequences=1,
                          max_generate_length=None, typical_sampling=False, typical_mass=.9, **hf_generate_kwargs):
         """
         Args:
@@ -716,7 +716,8 @@ class UnifiedVoice(nn.Module):
         if emo_cond_lengths is None:
             emo_cond_lengths = torch.tensor([emo_speech_condition.shape[-1]], device=speech_condition.device) 
 
-        speech_conditioning_latent = self.get_conditioning(speech_condition.transpose(1,2), cond_lengths)
+        if speech_conditioning_latent is None:
+            speech_conditioning_latent = self.get_conditioning(speech_condition.transpose(1,2), cond_lengths)
         if emo_vec is None:
             print('compute emo vec')
             emo_vec = self.get_emo_conditioning(emo_speech_condition.transpose(1,2), emo_cond_lengths)

--- a/indextts/infer_v2.py
+++ b/indextts/infer_v2.py
@@ -35,6 +35,18 @@ from transformers import SeamlessM4TFeatureExtractor
 import random
 import torch.nn.functional as F
 
+from indextts.reference_conditioning import (
+    get_or_create_cached,
+    merge_variable_length_tensors,
+    merge_weighted_vectors,
+    normalize_reference_inputs,
+)
+from indextts.emotion_reference_selection import (
+    expand_audio_like_emotion_rows,
+    normalize_emotion_input_rows,
+    resolve_speaker_reference_index,
+)
+
 class IndexTTS2:
     def __init__(
             self, cfg_path="checkpoints/config.yaml", model_dir="checkpoints", use_fp16=False, device=None,
@@ -202,13 +214,8 @@ class IndexTTS2:
         self.mel_fn = lambda x: mel_spectrogram(x, **mel_fn_args)
 
         # 缓存参考音频：
-        self.cache_spk_cond = None
-        self.cache_s2mel_style = None
-        self.cache_s2mel_prompt = None
-        self.cache_spk_audio_prompt = None
-        self.cache_emo_cond = None
-        self.cache_emo_audio_prompt = None
-        self.cache_mel = None
+        self.cache_spk_refs = {}
+        self.cache_emo_refs = {}
 
         # 进度引用显示（可选）
         self.gr_progress = None
@@ -323,11 +330,21 @@ class IndexTTS2:
         if self.gr_progress is not None:
             self.gr_progress(value, desc=desc)
 
-    def _load_and_cut_audio(self,audio_path,max_audio_length_seconds,verbose=False,sr=None):
-        if not sr:
-            audio, sr = librosa.load(audio_path)
-        else:
-            audio, _ = librosa.load(audio_path,sr=sr)
+    def _build_audio_load_error(self, audio_path, audio_role, exc):
+        return ValueError(
+            f"Failed to read {audio_role}: {audio_path}\n"
+            "Please convert the file to a standard PCM WAV or FLAC file and try again.\n"
+            f"Original error: {type(exc).__name__}: {exc}"
+        )
+
+    def _load_and_cut_audio(self, audio_path, max_audio_length_seconds, verbose=False, sr=None, audio_role="reference audio"):
+        try:
+            if not sr:
+                audio, sr = librosa.load(audio_path)
+            else:
+                audio, _ = librosa.load(audio_path, sr=sr)
+        except Exception as exc:
+            raise self._build_audio_load_error(audio_path, audio_role, exc) from exc
         audio = torch.tensor(audio).unsqueeze(0)
         max_audio_samples = int(max_audio_length_seconds * sr)
 
@@ -353,19 +370,240 @@ class IndexTTS2:
 
         return emo_vector
 
+    def _normalize_reference_inputs(self, refs, weights=None, label="reference"):
+        return normalize_reference_inputs(refs, weights, label=label)
+
+    def _merge_weighted_vectors(self, tensors, weights):
+        return merge_weighted_vectors(tensors, weights)
+
+    def _merge_weighted_sequence_tensors(self, tensors, weights, length_dim):
+        return merge_variable_length_tensors(tensors, weights, seq_dim=length_dim)
+
+    def _sequence_length(self, tensor):
+        return tensor.shape[1]
+
+    def _resolve_speaker_reference_for_emotion_row(self, row, speaker_references):
+        if not speaker_references:
+            raise ValueError("At least one speaker reference is required")
+
+        speaker_index = resolve_speaker_reference_index(row, len(speaker_references))
+        return speaker_index, speaker_references[speaker_index]
+
+    @torch.no_grad()
+    def _get_speaker_reference_features(self, audio_path, verbose=False):
+        cache_key = os.path.abspath(os.fspath(audio_path))
+
+        def factory():
+            audio, sr = self._load_and_cut_audio(
+                cache_key,
+                15,
+                verbose,
+                audio_role="speaker reference audio",
+            )
+            audio_22k = torchaudio.transforms.Resample(sr, 22050)(audio)
+            audio_16k = torchaudio.transforms.Resample(sr, 16000)(audio)
+
+            inputs = self.extract_features(audio_16k, sampling_rate=16000, return_tensors="pt")
+            input_features = inputs["input_features"].to(self.device)
+            attention_mask = inputs["attention_mask"].to(self.device)
+            spk_cond_emb = self.get_emb(input_features, attention_mask)
+
+            cond_lengths = torch.tensor([self._sequence_length(spk_cond_emb)], device=spk_cond_emb.device)
+            with torch.amp.autocast(
+                spk_cond_emb.device.type,
+                enabled=self.dtype is not None,
+                dtype=self.dtype,
+            ):
+                speech_conditioning_latent = self.gpt.get_conditioning(
+                    spk_cond_emb.transpose(1, 2),
+                    cond_lengths,
+                )
+
+            _, semantic_ref = self.semantic_codec.quantize(spk_cond_emb)
+            ref_mel = self.mel_fn(audio_22k.to(spk_cond_emb.device).float())
+            ref_target_lengths = torch.LongTensor([ref_mel.size(2)]).to(ref_mel.device)
+            feat = torchaudio.compliance.kaldi.fbank(
+                audio_16k.to(ref_mel.device),
+                num_mel_bins=80,
+                dither=0,
+                sample_frequency=16000,
+            )
+            feat = feat - feat.mean(dim=0, keepdim=True)
+            style = self.campplus_model(feat.unsqueeze(0))
+            prompt_condition = self.s2mel.models["length_regulator"](
+                semantic_ref,
+                ylens=ref_target_lengths,
+                n_quantizers=3,
+                f0=None,
+            )[0]
+
+            return {
+                "spk_cond_emb": spk_cond_emb,
+                "speech_conditioning_latent": speech_conditioning_latent,
+                "style": style,
+                "prompt_condition": prompt_condition,
+                "ref_mel": ref_mel,
+            }
+
+        return get_or_create_cached(self.cache_spk_refs, cache_key, factory)
+
+    @torch.no_grad()
+    def _get_emotion_reference_features(self, audio_path, verbose=False):
+        cache_key = os.path.abspath(os.fspath(audio_path))
+
+        def factory():
+            emo_audio, _ = self._load_and_cut_audio(
+                cache_key,
+                15,
+                verbose,
+                sr=16000,
+                audio_role="emotion reference audio",
+            )
+            emo_inputs = self.extract_features(emo_audio, sampling_rate=16000, return_tensors="pt")
+            emo_input_features = emo_inputs["input_features"].to(self.device)
+            emo_attention_mask = emo_inputs["attention_mask"].to(self.device)
+            emo_cond_emb = self.get_emb(emo_input_features, emo_attention_mask)
+            return {"emo_cond_emb": emo_cond_emb}
+
+        return get_or_create_cached(self.cache_emo_refs, cache_key, factory)
+
+    def _fuse_speaker_references(self, references, verbose=False):
+        speaker_features = [self._get_speaker_reference_features(ref.path, verbose=verbose) for ref in references]
+        weights = [ref.weight for ref in references]
+        return {
+            "spk_cond_emb": self._merge_weighted_sequence_tensors(
+                [feature["spk_cond_emb"] for feature in speaker_features], weights, length_dim=1
+            ),
+            "speech_conditioning_latent": self._merge_weighted_sequence_tensors(
+                [feature["speech_conditioning_latent"] for feature in speaker_features], weights, length_dim=1
+            ),
+            "style": self._merge_weighted_vectors(
+                [feature["style"] for feature in speaker_features], weights
+            ),
+            "prompt_condition": self._merge_weighted_sequence_tensors(
+                [feature["prompt_condition"] for feature in speaker_features], weights, length_dim=1
+            ),
+            "ref_mel": self._merge_weighted_sequence_tensors(
+                [feature["ref_mel"] for feature in speaker_features], weights, length_dim=2
+            ),
+        }
+
+    def _fuse_emotion_references(self, references, verbose=False):
+        emotion_features = [self._get_emotion_reference_features(ref.path, verbose=verbose) for ref in references]
+        weights = [ref.weight for ref in references]
+        return self._merge_weighted_sequence_tensors(
+            [feature["emo_cond_emb"] for feature in emotion_features], weights, length_dim=1
+        )
+
+    def _normalize_emotion_input_rows(self, emotion_references, default_text):
+        return normalize_emotion_input_rows(emotion_references, default_text)
+
+    def _build_emovec_from_control_vector(self, emo_vector, style, use_random=False, apply_bias=True):
+        processed_vector = list(emo_vector)
+        if apply_bias:
+            processed_vector = self.normalize_emo_vec(processed_vector, apply_bias=True)
+
+        weight_vector = torch.tensor(processed_vector, device=self.device)
+        if use_random:
+            random_index = [random.randint(0, x - 1) for x in self.emo_num]
+        else:
+            random_index = [find_most_similar_cosine(style, tmp) for tmp in self.spk_matrix]
+
+        emo_matrix = [tmp[index].unsqueeze(0) for index, tmp in zip(random_index, self.emo_matrix)]
+        emo_matrix = torch.cat(emo_matrix, 0)
+        emovec_mat = weight_vector.unsqueeze(1) * emo_matrix
+        emovec_mat = torch.sum(emovec_mat, 0)
+        return emovec_mat.unsqueeze(0)
+
+    def _expand_audio_like_emotion_rows(self, emotion_rows, speaker_references):
+        return expand_audio_like_emotion_rows(emotion_rows, speaker_references)
+
+    def _resolve_structured_emotion_conditioning(
+        self,
+        emotion_rows,
+        speaker_references,
+        spk_cond_emb,
+        spk_cond_lengths,
+        style,
+        text,
+        use_random=False,
+        verbose=False,
+    ):
+        has_non_audio_rows = any(row["type"] in {"vector", "text"} for row in emotion_rows)
+        if not has_non_audio_rows:
+            emotion_references = self._expand_audio_like_emotion_rows(emotion_rows, speaker_references)
+            emo_cond_emb = self._fuse_emotion_references(emotion_references, verbose=verbose)
+            emo_cond_lengths = torch.tensor([self._sequence_length(emo_cond_emb)], device=self.device)
+            return emo_cond_emb, emo_cond_lengths, None
+
+        merged_vectors = []
+        weights = []
+        speaker_emovecs = {}
+        for row in emotion_rows:
+            row_type = row["type"]
+            if row_type == "speaker":
+                _, speaker_ref = self._resolve_speaker_reference_for_emotion_row(
+                    row,
+                    speaker_references,
+                )
+                speaker_emovec = speaker_emovecs.get(speaker_ref.path)
+                if speaker_emovec is None:
+                    emotion_cond_emb = self._get_emotion_reference_features(
+                        speaker_ref.path,
+                        verbose=verbose,
+                    )["emo_cond_emb"]
+                    speaker_cond_lengths = torch.tensor(
+                        [self._sequence_length(emotion_cond_emb)],
+                        device=self.device,
+                    )
+                    speaker_emovec = self.gpt.get_emovec(emotion_cond_emb, speaker_cond_lengths)
+                    speaker_emovecs[speaker_ref.path] = speaker_emovec
+                merged_vectors.append(speaker_emovec)
+            elif row_type == "audio":
+                emo_cond_emb = self._get_emotion_reference_features(row["path"], verbose=verbose)["emo_cond_emb"]
+                emo_cond_lengths = torch.tensor([self._sequence_length(emo_cond_emb)], device=self.device)
+                merged_vectors.append(self.gpt.get_emovec(emo_cond_emb, emo_cond_lengths))
+            elif row_type == "vector":
+                merged_vectors.append(
+                    self._build_emovec_from_control_vector(
+                        row["vector"],
+                        style,
+                        use_random=use_random,
+                        apply_bias=True,
+                    )
+                )
+            else:
+                emo_dict = self.qwen_emo.inference(row["text"] or text)
+                merged_vectors.append(
+                    self._build_emovec_from_control_vector(
+                        list(emo_dict.values()),
+                        style,
+                        use_random=use_random,
+                        apply_bias=False,
+                    )
+                )
+            weights.append(row["weight"])
+
+        return spk_cond_emb, spk_cond_lengths, self._merge_weighted_vectors(merged_vectors, weights)
+
     # 原始推理模式
     def infer(self, spk_audio_prompt, text, output_path,
               emo_audio_prompt=None, emo_alpha=1.0,
               emo_vector=None,
               use_emo_text=False, emo_text=None, use_random=False, interval_silence=200,
-              verbose=False, max_text_tokens_per_segment=120, stream_return=False, more_segment_before=0, **generation_kwargs):
+              verbose=False, max_text_tokens_per_segment=120, stream_return=False, more_segment_before=0,
+              spk_audio_weights=None, emo_audio_weights=None, emotion_references=None, **generation_kwargs):
         if stream_return:
             return self.infer_generator(
                 spk_audio_prompt, text, output_path,
                 emo_audio_prompt, emo_alpha,
                 emo_vector,
                 use_emo_text, emo_text, use_random, interval_silence,
-                verbose, max_text_tokens_per_segment, stream_return, more_segment_before, **generation_kwargs
+                verbose, max_text_tokens_per_segment, stream_return, more_segment_before,
+                spk_audio_weights=spk_audio_weights,
+                emo_audio_weights=emo_audio_weights,
+                emotion_references=emotion_references,
+                **generation_kwargs
             )
         else:
             try:
@@ -374,7 +612,11 @@ class IndexTTS2:
                     emo_audio_prompt, emo_alpha,
                     emo_vector,
                     use_emo_text, emo_text, use_random, interval_silence,
-                    verbose, max_text_tokens_per_segment, stream_return, more_segment_before, **generation_kwargs
+                    verbose, max_text_tokens_per_segment, stream_return, more_segment_before,
+                    spk_audio_weights=spk_audio_weights,
+                    emo_audio_weights=emo_audio_weights,
+                    emotion_references=emotion_references,
+                    **generation_kwargs
                 ))[0]
             except IndexError:
                 return None
@@ -383,22 +625,30 @@ class IndexTTS2:
               emo_audio_prompt=None, emo_alpha=1.0,
               emo_vector=None,
               use_emo_text=False, emo_text=None, use_random=False, interval_silence=200,
-              verbose=False, max_text_tokens_per_segment=120, stream_return=False, quick_streaming_tokens=0, **generation_kwargs):
+              verbose=False, max_text_tokens_per_segment=120, stream_return=False, quick_streaming_tokens=0,
+              spk_audio_weights=None, emo_audio_weights=None, emotion_references=None, **generation_kwargs):
         print(">> starting inference...")
         self._set_gr_progress(0, "starting inference...")
         if verbose:
             print(f"origin text:{text}, spk_audio_prompt:{spk_audio_prompt}, "
                   f"emo_audio_prompt:{emo_audio_prompt}, emo_alpha:{emo_alpha}, "
                   f"emo_vector:{emo_vector}, use_emo_text:{use_emo_text}, "
-                  f"emo_text:{emo_text}")
+                  f"emo_text:{emo_text}, spk_audio_weights:{spk_audio_weights}, "
+                  f"emo_audio_weights:{emo_audio_weights}, emotion_references:{emotion_references}")
         start_time = time.perf_counter()
+        speaker_references = self._normalize_reference_inputs(
+            spk_audio_prompt,
+            spk_audio_weights,
+            "speaker references",
+        )
+        structured_emotion_rows = self._normalize_emotion_input_rows(emotion_references, text)
 
-        if use_emo_text or emo_vector is not None:
+        if structured_emotion_rows is None and (use_emo_text or emo_vector is not None):
             # we're using a text or emotion vector guidance; so we must remove
             # "emotion reference voice", to ensure we use correct emotion mixing!
             emo_audio_prompt = None
 
-        if use_emo_text:
+        if structured_emotion_rows is None and use_emo_text:
             # automatically generate emotion vectors from text prompt
             if emo_text is None:
                 emo_text = text  # use main text prompt
@@ -407,7 +657,7 @@ class IndexTTS2:
             # convert ordered dict to list of vectors; the order is VERY important!
             emo_vector = list(emo_dict.values())
 
-        if emo_vector is not None:
+        if structured_emotion_rows is None and emo_vector is not None:
             # we have emotion vectors; they can't be blended via alpha mixing
             # in the main inference process later, so we must pre-calculate
             # their new strengths here based on the alpha instead!
@@ -417,87 +667,64 @@ class IndexTTS2:
                 emo_vector = [int(x * emo_vector_scale * 10000) / 10000 for x in emo_vector]
                 print(f"scaled emotion vectors to {emo_vector_scale}x: {emo_vector}")
 
-        if emo_audio_prompt is None:
-            # we are not using any external "emotion reference voice"; use
-            # speaker's voice as the main emotion reference audio.
-            emo_audio_prompt = spk_audio_prompt
-            # must always use alpha=1.0 when we don't have an external reference voice
+        if structured_emotion_rows is not None:
+            emotion_references = None
             emo_alpha = 1.0
+        elif emo_audio_prompt is None and emo_vector is None:
+            emotion_references = speaker_references
+            emo_alpha = 1.0
+        elif emo_audio_prompt is not None:
+            emotion_references = self._normalize_reference_inputs(
+                emo_audio_prompt,
+                emo_audio_weights,
+                "emotion references",
+            )
+        else:
+            emotion_references = None
 
         # 如果参考音频改变了，才需要重新生成, 提升速度
-        if self.cache_spk_cond is None or self.cache_spk_audio_prompt != spk_audio_prompt:
-            if self.cache_spk_cond is not None:
-                self.cache_spk_cond = None
-                self.cache_s2mel_style = None
-                self.cache_s2mel_prompt = None
-                self.cache_mel = None
-                torch.cuda.empty_cache()
-            audio,sr = self._load_and_cut_audio(spk_audio_prompt,15,verbose)
-            audio_22k = torchaudio.transforms.Resample(sr, 22050)(audio)
-            audio_16k = torchaudio.transforms.Resample(sr, 16000)(audio)
+        if verbose:
+            print("speaker references:", [(ref.path, ref.weight) for ref in speaker_references])
+            if structured_emotion_rows is not None:
+                print("structured emotion rows:", structured_emotion_rows)
+            if emotion_references is not None:
+                print("emotion references:", [(ref.path, ref.weight) for ref in emotion_references])
 
-            inputs = self.extract_features(audio_16k, sampling_rate=16000, return_tensors="pt")
-            input_features = inputs["input_features"]
-            attention_mask = inputs["attention_mask"]
-            input_features = input_features.to(self.device)
-            attention_mask = attention_mask.to(self.device)
-            spk_cond_emb = self.get_emb(input_features, attention_mask)
+        fused_speaker = self._fuse_speaker_references(speaker_references, verbose=verbose)
+        spk_cond_emb = fused_speaker["spk_cond_emb"]
+        speech_conditioning_latent = fused_speaker["speech_conditioning_latent"]
+        style = fused_speaker["style"]
+        prompt_condition = fused_speaker["prompt_condition"]
+        ref_mel = fused_speaker["ref_mel"]
+        spk_cond_lengths = torch.tensor([spk_cond_emb.shape[1]], device=self.device)
+        emo_cond_emb = None
+        emo_cond_lengths = None
+        explicit_emovec = None
 
-            _, S_ref = self.semantic_codec.quantize(spk_cond_emb)
-            ref_mel = self.mel_fn(audio_22k.to(spk_cond_emb.device).float())
-            ref_target_lengths = torch.LongTensor([ref_mel.size(2)]).to(ref_mel.device)
-            feat = torchaudio.compliance.kaldi.fbank(audio_16k.to(ref_mel.device),
-                                                     num_mel_bins=80,
-                                                     dither=0,
-                                                     sample_frequency=16000)
-            feat = feat - feat.mean(dim=0, keepdim=True)  # feat2另外一个滤波器能量组特征[922, 80]
-            style = self.campplus_model(feat.unsqueeze(0))  # 参考音频的全局style2[1,192]
 
-            prompt_condition = self.s2mel.models['length_regulator'](S_ref,
-                                                                     ylens=ref_target_lengths,
-                                                                     n_quantizers=3,
-                                                                     f0=None)[0]
-
-            self.cache_spk_cond = spk_cond_emb
-            self.cache_s2mel_style = style
-            self.cache_s2mel_prompt = prompt_condition
-            self.cache_spk_audio_prompt = spk_audio_prompt
-            self.cache_mel = ref_mel
+        if structured_emotion_rows is not None:
+            emo_cond_emb, emo_cond_lengths, explicit_emovec = self._resolve_structured_emotion_conditioning(
+                structured_emotion_rows,
+                speaker_references,
+                spk_cond_emb,
+                spk_cond_lengths,
+                style,
+                text,
+                use_random=use_random,
+                verbose=verbose,
+            )
+        elif emo_vector is not None:
+            explicit_emovec = self._build_emovec_from_control_vector(
+                emo_vector,
+                style,
+                use_random=use_random,
+                apply_bias=False,
+            )
+            emo_cond_emb = spk_cond_emb
+            emo_cond_lengths = spk_cond_lengths
         else:
-            style = self.cache_s2mel_style
-            prompt_condition = self.cache_s2mel_prompt
-            spk_cond_emb = self.cache_spk_cond
-            ref_mel = self.cache_mel
-
-        if emo_vector is not None:
-            weight_vector = torch.tensor(emo_vector, device=self.device)
-            if use_random:
-                random_index = [random.randint(0, x - 1) for x in self.emo_num]
-            else:
-                random_index = [find_most_similar_cosine(style, tmp) for tmp in self.spk_matrix]
-
-            emo_matrix = [tmp[index].unsqueeze(0) for index, tmp in zip(random_index, self.emo_matrix)]
-            emo_matrix = torch.cat(emo_matrix, 0)
-            emovec_mat = weight_vector.unsqueeze(1) * emo_matrix
-            emovec_mat = torch.sum(emovec_mat, 0)
-            emovec_mat = emovec_mat.unsqueeze(0)
-
-        if self.cache_emo_cond is None or self.cache_emo_audio_prompt != emo_audio_prompt:
-            if self.cache_emo_cond is not None:
-                self.cache_emo_cond = None
-                torch.cuda.empty_cache()
-            emo_audio, _ = self._load_and_cut_audio(emo_audio_prompt,15,verbose,sr=16000)
-            emo_inputs = self.extract_features(emo_audio, sampling_rate=16000, return_tensors="pt")
-            emo_input_features = emo_inputs["input_features"]
-            emo_attention_mask = emo_inputs["attention_mask"]
-            emo_input_features = emo_input_features.to(self.device)
-            emo_attention_mask = emo_attention_mask.to(self.device)
-            emo_cond_emb = self.get_emb(emo_input_features, emo_attention_mask)
-
-            self.cache_emo_cond = emo_cond_emb
-            self.cache_emo_audio_prompt = emo_audio_prompt
-        else:
-            emo_cond_emb = self.cache_emo_cond
+            emo_cond_emb = self._fuse_emotion_references(emotion_references, verbose=verbose)
+            emo_cond_lengths = torch.tensor([self._sequence_length(emo_cond_emb)], device=self.device)
 
         self._set_gr_progress(0.1, "text processing...")
         text_tokens_list = self.tokenizer.tokenize(text)
@@ -549,24 +776,24 @@ class IndexTTS2:
             m_start_time = time.perf_counter()
             with torch.no_grad():
                 with torch.amp.autocast(text_tokens.device.type, enabled=self.dtype is not None, dtype=self.dtype):
-                    emovec = self.gpt.merge_emovec(
-                        spk_cond_emb,
-                        emo_cond_emb,
-                        torch.tensor([spk_cond_emb.shape[-1]], device=text_tokens.device),
-                        torch.tensor([emo_cond_emb.shape[-1]], device=text_tokens.device),
-                        alpha=emo_alpha
-                    )
-
-                    if emo_vector is not None:
-                        emovec = emovec_mat + (1 - torch.sum(weight_vector)) * emovec
-                        # emovec = emovec_mat
+                    if explicit_emovec is None:
+                        emovec = self.gpt.merge_emovec(
+                            spk_cond_emb,
+                            emo_cond_emb,
+                            spk_cond_lengths.to(text_tokens.device),
+                            emo_cond_lengths.to(text_tokens.device),
+                            alpha=emo_alpha
+                        )
+                    else:
+                        emovec = explicit_emovec
 
                     codes, speech_conditioning_latent = self.gpt.inference_speech(
                         spk_cond_emb,
                         text_tokens,
                         emo_cond_emb,
-                        cond_lengths=torch.tensor([spk_cond_emb.shape[-1]], device=text_tokens.device),
-                        emo_cond_lengths=torch.tensor([emo_cond_emb.shape[-1]], device=text_tokens.device),
+                        cond_lengths=spk_cond_lengths.to(text_tokens.device),
+                        emo_cond_lengths=emo_cond_lengths.to(text_tokens.device),
+                        speech_conditioning_latent=speech_conditioning_latent,
                         emo_vec=emovec,
                         do_sample=True,
                         top_p=top_p,
@@ -624,10 +851,10 @@ class IndexTTS2:
                         codes,
                         torch.tensor([codes.shape[-1]], device=text_tokens.device),
                         emo_cond_emb,
-                        cond_mel_lengths=torch.tensor([spk_cond_emb.shape[-1]], device=text_tokens.device),
-                        emo_cond_mel_lengths=torch.tensor([emo_cond_emb.shape[-1]], device=text_tokens.device),
+                        emo_cond_mel_lengths=emo_cond_lengths.to(text_tokens.device),
                         emo_vec=emovec,
                         use_speed=use_speed,
+                        do_spk_cond=False,
                     )
                     gpt_forward_time += time.perf_counter() - m_start_time
 

--- a/indextts/reference_conditioning.py
+++ b/indextts/reference_conditioning.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Callable, MutableMapping, Sequence, TypeVar
+
+import torch
+
+
+@dataclass(frozen=True)
+class WeightedReference:
+    path: str
+    weight: float
+
+
+T = TypeVar("T")
+
+
+def normalize_reference_inputs(reference_paths, weights=None, label="references"):
+    refs = _coerce_reference_paths(reference_paths, label)
+    normalized_weights = _normalize_weights(weights, len(refs), label)
+    return [
+        WeightedReference(path=path, weight=weight)
+        for path, weight in zip(refs, normalized_weights)
+    ]
+
+
+def merge_weighted_vectors(tensors: Sequence[torch.Tensor], weights: Sequence[float]) -> torch.Tensor:
+    if not tensors:
+        raise ValueError("Expected at least one tensor to merge")
+    if len(tensors) != len(weights):
+        raise ValueError("Tensor and weight counts must match")
+    if len(tensors) == 1:
+        return tensors[0]
+
+    ref_tensor = tensors[0]
+    weight_tensor = torch.tensor(weights, device=ref_tensor.device, dtype=ref_tensor.dtype)
+    stacked = torch.stack([tensor.to(device=ref_tensor.device, dtype=ref_tensor.dtype) for tensor in tensors], dim=0)
+    weight_shape = [len(weights)] + [1] * (stacked.ndim - 1)
+    return (stacked * weight_tensor.view(*weight_shape)).sum(dim=0)
+
+
+def merge_variable_length_tensors(
+    tensors: Sequence[torch.Tensor],
+    weights: Sequence[float],
+    seq_dim: int = -1,
+) -> torch.Tensor:
+    if not tensors:
+        raise ValueError("Expected at least one tensor to merge")
+    if len(tensors) != len(weights):
+        raise ValueError("Tensor and weight counts must match")
+    if len(tensors) == 1:
+        return tensors[0]
+
+    normalized_tensors = [tensor.movedim(seq_dim, -1) for tensor in tensors]
+    ref_non_sequence_shape = normalized_tensors[0].shape[:-1]
+    for index, tensor in enumerate(normalized_tensors[1:], start=1):
+        if tensor.shape[:-1] != ref_non_sequence_shape:
+            raise ValueError(
+                "All tensor dimensions except the sequence dimension must match for merging. "
+                f"Expected {ref_non_sequence_shape} before the sequence axis, got {tensor.shape[:-1]} "
+                f"for tensor index {index}. Check the seq_dim argument."
+            )
+    lengths = torch.tensor(
+        [tensor.shape[-1] for tensor in normalized_tensors],
+        device=normalized_tensors[0].device,
+        dtype=torch.long,
+    )
+    max_len = int(lengths.max().item())
+    ref_tensor = normalized_tensors[0]
+    padded = []
+    for tensor in normalized_tensors:
+        pad_shape = list(tensor.shape)
+        pad_shape[-1] = max_len
+        padded_tensor = tensor.new_zeros(pad_shape)
+        padded_tensor[..., : tensor.shape[-1]] = tensor
+        padded.append(padded_tensor)
+
+    stacked = torch.stack(padded, dim=0)
+    weight_tensor = torch.tensor(weights, device=ref_tensor.device, dtype=ref_tensor.dtype)
+    frame_index = torch.arange(max_len, device=ref_tensor.device)
+    active_mask = frame_index.unsqueeze(0) < lengths.unsqueeze(1)
+    weighted_mask = weight_tensor.unsqueeze(1) * active_mask.to(weight_tensor.dtype)
+    denominator = weighted_mask.sum(dim=0).clamp_min(torch.finfo(weight_tensor.dtype).eps)
+    normalized_mask = weighted_mask / denominator.unsqueeze(0)
+    weight_shape = [len(tensors)] + [1] * (stacked.ndim - 2) + [max_len]
+    merged = (stacked * normalized_mask.view(*weight_shape)).sum(dim=0)
+    return merged.movedim(-1, seq_dim)
+
+
+def get_or_create_cached(cache: MutableMapping[str, T], key: str, factory: Callable[[], T]) -> T:
+    cached = cache.get(key)
+    if cached is not None:
+        return cached
+
+    cache[key] = factory()
+    return cache[key]
+
+
+def _coerce_reference_paths(reference_paths, label: str) -> list[str]:
+    if isinstance(reference_paths, (str, os.PathLike)):
+        raw_paths = [reference_paths]
+    elif isinstance(reference_paths, Sequence):
+        raw_paths = list(reference_paths)
+    else:
+        raise TypeError(f"{label} must be a path or a sequence of paths")
+
+    paths = []
+    for raw_path in raw_paths:
+        if raw_path is None:
+            continue
+        path = os.fspath(raw_path).strip()
+        if path:
+            paths.append(os.path.abspath(path))
+
+    if not paths:
+        raise ValueError(f"At least one {label} entry is required")
+    return paths
+
+
+def _normalize_weights(weights, count: int, label: str) -> list[float]:
+    if weights is None:
+        return [1.0 / count] * count
+
+    if isinstance(weights, (int, float)):
+        raw_weights = [float(weights)]
+    elif isinstance(weights, Sequence) and not isinstance(weights, (str, bytes)):
+        raw_weights = [float(weight) for weight in weights]
+    else:
+        raise TypeError(f"{label} weights must be numeric or a sequence of numerics")
+
+    if len(raw_weights) != count:
+        raise ValueError(f"{label} weights must match the number of references")
+    if any(weight < 0 for weight in raw_weights):
+        raise ValueError(f"{label} weights must be non-negative")
+
+    weight_sum = sum(raw_weights)
+    if weight_sum <= 0:
+        raise ValueError(f"{label} weights must sum to a value greater than 0")
+
+    return [weight / weight_sum for weight in raw_weights]

--- a/indextts/webui_reference_inputs.py
+++ b/indextts/webui_reference_inputs.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import os
+
+
+def normalize_uploaded_path(value):
+    if value is None:
+        return None
+    if isinstance(value, str):
+        path = value.strip()
+        return path or None
+    if hasattr(value, "name"):
+        path = str(value.name).strip()
+        return path or None
+    return None
+
+
+def collect_speaker_references(values):
+    speaker_refs = []
+    weights = []
+    for row in values:
+        if not row["active"]:
+            continue
+        audio_path = normalize_uploaded_path(row["audio"])
+        if audio_path is None:
+            continue
+        speaker_refs.append(audio_path)
+        weights.append(clamp_weight(row["weight"]))
+
+    if not speaker_refs:
+        raise ValueError("At least one speaker reference audio is required.")
+    return speaker_refs, weights
+
+
+def list_speaker_reference_targets(values):
+    targets = []
+    for row in values:
+        if not row["active"]:
+            continue
+        audio_path = normalize_uploaded_path(row["audio"])
+        if audio_path is None:
+            continue
+        targets.append((len(targets), audio_path))
+    return targets
+
+
+def collect_emotion_references(values, synthesis_text, normalize_emo_vector, emotion_type_speaker, emotion_type_audio, emotion_type_vector, emotion_type_text):
+    emotion_refs = []
+    for row in values:
+        if not row["active"]:
+            continue
+
+        row_type = row["type"] or emotion_type_speaker
+        weight = clamp_weight(row["weight"])
+        if row_type == emotion_type_speaker:
+            emotion_row = {"type": emotion_type_speaker, "weight": weight}
+            speaker_index = row.get("speaker_index")
+            if speaker_index not in (None, ""):
+                try:
+                    emotion_row["speaker_index"] = int(speaker_index)
+                except (TypeError, ValueError) as exc:
+                    raise ValueError("Speaker-linked emotion rows require a valid speaker selection.") from exc
+            emotion_refs.append(emotion_row)
+            continue
+
+        if row_type == emotion_type_audio:
+            audio_path = normalize_uploaded_path(row["audio"])
+            if audio_path is None:
+                continue
+            emotion_refs.append({"type": emotion_type_audio, "path": audio_path, "weight": weight})
+            continue
+
+        if row_type == emotion_type_vector:
+            emotion_refs.append(
+                {
+                    "type": emotion_type_vector,
+                    "vector": normalize_emo_vector(row["vector"], apply_bias=True),
+                    "weight": weight,
+                }
+            )
+            continue
+
+        text_value = (row["text"] or "").strip()
+        if not text_value:
+            text_value = synthesis_text
+        if not text_value:
+            raise ValueError("Emotion text row is empty and synthesis text is also empty.")
+        emotion_refs.append({"type": emotion_type_text, "text": text_value, "weight": weight})
+
+    if not emotion_refs:
+        return [{"type": emotion_type_speaker, "weight": 1.0}]
+    return emotion_refs
+
+
+def clamp_weight(value):
+    try:
+        return max(0.0, min(1.0, float(value)))
+    except (TypeError, ValueError):
+        return 0.0

--- a/tests/test_emotion_reference_speaker_selection.py
+++ b/tests/test_emotion_reference_speaker_selection.py
@@ -1,0 +1,148 @@
+import unittest
+
+from indextts.emotion_reference_selection import (
+    expand_audio_like_emotion_rows,
+    normalize_emotion_input_rows,
+    resolve_speaker_reference_index,
+)
+from indextts.reference_conditioning import WeightedReference
+from indextts.webui_reference_inputs import (
+    collect_emotion_references,
+    list_speaker_reference_targets,
+)
+
+
+class EmotionReferenceSpeakerSelectionTests(unittest.TestCase):
+    def test_normalize_emotion_input_rows_keeps_speaker_index(self):
+        rows = normalize_emotion_input_rows(
+            [
+                {"type": "speaker", "speaker_index": "1", "weight": 3},
+                {"type": "audio", "path": "emotion.wav", "weight": 1},
+            ],
+            "hello",
+        )
+
+        self.assertEqual(rows[0]["speaker_index"], 1)
+        self.assertEqual([row["weight"] for row in rows], [0.75, 0.25])
+
+    def test_resolve_speaker_reference_index_requires_multi_speaker_selection(self):
+        with self.assertRaises(ValueError):
+            resolve_speaker_reference_index({"type": "speaker"}, 2)
+
+    def test_resolve_speaker_reference_index_defaults_single_speaker(self):
+        self.assertEqual(resolve_speaker_reference_index({"type": "speaker"}, 1), 0)
+
+    def test_resolve_speaker_reference_index_rejects_out_of_range_value(self):
+        with self.assertRaises(ValueError):
+            resolve_speaker_reference_index({"type": "speaker", "speaker_index": 2}, 2)
+
+    def test_expand_audio_like_emotion_rows_uses_only_selected_speaker_reference(self):
+        speaker_references = [
+            WeightedReference(path="speaker_a.wav", weight=0.25),
+            WeightedReference(path="speaker_b.wav", weight=0.75),
+        ]
+
+        expanded = expand_audio_like_emotion_rows(
+            [
+                {"type": "speaker", "speaker_index": 1, "weight": 0.6},
+                {"type": "audio", "path": "emotion.wav", "weight": 0.4},
+            ],
+            speaker_references,
+        )
+
+        self.assertEqual(
+            [(reference.path, reference.weight) for reference in expanded],
+            [("speaker_b.wav", 0.6), ("emotion.wav", 0.4)],
+        )
+
+    def test_expand_audio_like_emotion_rows_supports_multiple_targeted_speaker_rows(self):
+        speaker_references = [
+            WeightedReference(path="speaker_a.wav", weight=0.5),
+            WeightedReference(path="speaker_b.wav", weight=0.5),
+        ]
+
+        expanded = expand_audio_like_emotion_rows(
+            [
+                {"type": "speaker", "speaker_index": 0, "weight": 0.3},
+                {"type": "speaker", "speaker_index": 1, "weight": 0.7},
+            ],
+            speaker_references,
+        )
+
+        self.assertEqual(
+            [(reference.path, reference.weight) for reference in expanded],
+            [("speaker_a.wav", 0.3), ("speaker_b.wav", 0.7)],
+        )
+
+    def test_list_speaker_reference_targets_skips_empty_or_inactive_rows(self):
+        targets = list_speaker_reference_targets(
+            [
+                {"active": True, "audio": "speaker_a.wav"},
+                {"active": True, "audio": None},
+                {"active": False, "audio": "speaker_unused.wav"},
+                {"active": True, "audio": " speaker_b.wav "},
+            ]
+        )
+
+        self.assertEqual([index for index, _ in targets], [0, 1])
+        self.assertTrue(targets[0][1].endswith("speaker_a.wav"))
+        self.assertTrue(targets[1][1].endswith("speaker_b.wav"))
+
+    def test_collect_emotion_references_preserves_selected_speaker_index(self):
+        refs = collect_emotion_references(
+            [
+                {
+                    "active": True,
+                    "type": "speaker",
+                    "speaker_index": "1",
+                    "weight": 0.6,
+                    "audio": None,
+                    "text": "",
+                    "vector": [0.0] * 8,
+                },
+                {
+                    "active": True,
+                    "type": "text",
+                    "speaker_index": None,
+                    "weight": 0.4,
+                    "audio": None,
+                    "text": "calm",
+                    "vector": [0.0] * 8,
+                },
+            ],
+            "hello",
+            lambda values, apply_bias=True: values,
+            "speaker",
+            "audio",
+            "vector",
+            "text",
+        )
+
+        self.assertEqual(refs[0], {"type": "speaker", "speaker_index": 1, "weight": 0.6})
+        self.assertEqual(refs[1]["type"], "text")
+
+    def test_collect_emotion_references_rejects_invalid_speaker_selection(self):
+        with self.assertRaises(ValueError):
+            collect_emotion_references(
+                [
+                    {
+                        "active": True,
+                        "type": "speaker",
+                        "speaker_index": "bad",
+                        "weight": 1.0,
+                        "audio": None,
+                        "text": "",
+                        "vector": [0.0] * 8,
+                    }
+                ],
+                "hello",
+                lambda values, apply_bias=True: values,
+                "speaker",
+                "audio",
+                "vector",
+                "text",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_multi_reference_conditioning.py
+++ b/tests/test_multi_reference_conditioning.py
@@ -1,0 +1,86 @@
+import unittest
+
+import torch
+
+from indextts.reference_conditioning import (
+    get_or_create_cached,
+    merge_variable_length_tensors,
+    merge_weighted_vectors,
+    normalize_reference_inputs,
+)
+
+
+class MultiReferenceConditioningTests(unittest.TestCase):
+    def test_normalize_reference_inputs_defaults_to_equal_weights(self):
+        refs = normalize_reference_inputs(
+            ["speaker_a.wav", "speaker_b.wav", "speaker_c.wav"],
+            None,
+            label="speaker reference",
+        )
+        self.assertEqual([ref.path.endswith(name) for ref, name in zip(refs, ["speaker_a.wav", "speaker_b.wav", "speaker_c.wav"])], [True, True, True])
+        self.assertEqual([ref.weight for ref in refs], [1 / 3, 1 / 3, 1 / 3])
+
+    def test_normalize_reference_inputs_normalizes_custom_weights(self):
+        refs = normalize_reference_inputs(
+            ["speaker_a.wav", "speaker_b.wav"],
+            [2, 6],
+            label="speaker reference",
+        )
+        self.assertEqual([ref.weight for ref in refs], [0.25, 0.75])
+
+    def test_normalize_reference_inputs_rejects_invalid_weights(self):
+        with self.assertRaises(ValueError):
+            normalize_reference_inputs(["speaker_a.wav", "speaker_b.wav"], [1], label="speaker reference")
+
+        with self.assertRaises(ValueError):
+            normalize_reference_inputs(["speaker_a.wav", "speaker_b.wav"], [1, -1], label="speaker reference")
+
+        with self.assertRaises(ValueError):
+            normalize_reference_inputs(["speaker_a.wav", "speaker_b.wav"], [0, 0], label="speaker reference")
+
+    def test_merge_variable_length_tensors_renormalizes_tails(self):
+        first = torch.tensor([[[1.0], [3.0], [5.0]]])
+        second = torch.tensor([[[10.0]]])
+        merged = merge_variable_length_tensors([first, second], [0.2, 0.8], seq_dim=1)
+        expected = torch.tensor([[[8.2], [3.0], [5.0]]])
+        self.assertTrue(torch.allclose(merged, expected))
+
+    def test_merge_variable_length_tensors_supports_middle_sequence_axis(self):
+        first = torch.ones(1, 2, 3)
+        second = torch.full((1, 4, 3), 3.0)
+        merged = merge_variable_length_tensors([first, second], [0.25, 0.75], seq_dim=1)
+        expected = torch.tensor(
+            [[[2.5, 2.5, 2.5], [2.5, 2.5, 2.5], [3.0, 3.0, 3.0], [3.0, 3.0, 3.0]]]
+        )
+        self.assertTrue(torch.allclose(merged, expected))
+
+    def test_merge_variable_length_tensors_rejects_wrong_sequence_axis(self):
+        first = torch.ones(1, 2, 3)
+        second = torch.ones(1, 4, 3)
+        with self.assertRaises(ValueError):
+            merge_variable_length_tensors([first, second], [0.5, 0.5], seq_dim=2)
+
+    def test_merge_weighted_vectors(self):
+        merged = merge_weighted_vectors(
+            [torch.tensor([[2.0, 4.0]]), torch.tensor([[20.0, 40.0]])],
+            [0.25, 0.75],
+        )
+        self.assertTrue(torch.allclose(merged, torch.tensor([[15.5, 31.0]])))
+
+    def test_get_or_create_cached_reuses_factory_result(self):
+        cache = {}
+        calls = {"count": 0}
+
+        def factory():
+            calls["count"] += 1
+            return {"value": 42}
+
+        first = get_or_create_cached(cache, "emotion.wav", factory)
+        second = get_or_create_cached(cache, "emotion.wav", factory)
+
+        self.assertIs(first, second)
+        self.assertEqual(calls["count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webui.py
+++ b/webui.py
@@ -1,10 +1,8 @@
 import html
-import json
 import os
 import sys
-import threading
 import time
-
+import traceback
 import warnings
 
 warnings.filterwarnings("ignore", category=FutureWarning)
@@ -17,6 +15,18 @@ sys.path.append(current_dir)
 sys.path.append(os.path.join(current_dir, "indextts"))
 
 import argparse
+
+import gradio as gr
+
+from indextts.infer_v2 import IndexTTS2
+from indextts.webui_reference_inputs import (
+    collect_emotion_references as collect_emotion_references_payload,
+    collect_speaker_references as collect_speaker_references_payload,
+    list_speaker_reference_targets,
+)
+from tools.i18n.i18n import I18nAuto
+
+
 parser = argparse.ArgumentParser(
     description="IndexTTS WebUI",
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -35,82 +45,60 @@ if not os.path.exists(cmd_args.model_dir):
     print(f"Model directory {cmd_args.model_dir} does not exist. Please download the model first.")
     sys.exit(1)
 
-for file in [
+for file_name in [
     "bpe.model",
     "gpt.pth",
     "config.yaml",
     "s2mel.pth",
-    "wav2vec2bert_stats.pt"
+    "wav2vec2bert_stats.pt",
 ]:
-    file_path = os.path.join(cmd_args.model_dir, file)
+    file_path = os.path.join(cmd_args.model_dir, file_name)
     if not os.path.exists(file_path):
         print(f"Required file {file_path} does not exist. Please download it.")
         sys.exit(1)
 
-import gradio as gr
-from indextts.infer_v2 import IndexTTS2
-from tools.i18n.i18n import I18nAuto
-
 i18n = I18nAuto(language="Auto")
-MODE = 'local'
-tts = IndexTTS2(model_dir=cmd_args.model_dir,
-                cfg_path=os.path.join(cmd_args.model_dir, "config.yaml"),
-                use_fp16=cmd_args.fp16,
-                use_deepspeed=cmd_args.deepspeed,
-                use_cuda_kernel=cmd_args.cuda_kernel,
-                )
-# 支持的语言列表
-LANGUAGES = {
-    "中文": "zh_CN",
-    "English": "en_US"
-}
-EMO_CHOICES_ALL = [i18n("与音色参考音频相同"),
-                i18n("使用情感参考音频"),
-                i18n("使用情感向量控制"),
-                i18n("使用情感描述文本控制")]
-EMO_CHOICES_OFFICIAL = EMO_CHOICES_ALL[:-1]  # skip experimental features
+tts = IndexTTS2(
+    model_dir=cmd_args.model_dir,
+    cfg_path=os.path.join(cmd_args.model_dir, "config.yaml"),
+    use_fp16=cmd_args.fp16,
+    use_deepspeed=cmd_args.deepspeed,
+    use_cuda_kernel=cmd_args.cuda_kernel,
+)
 
-os.makedirs("outputs/tasks",exist_ok=True)
-os.makedirs("prompts",exist_ok=True)
+MAX_SPEAKER_ROWS = 8
+MAX_EMOTION_ROWS = 8
+EMOTION_VECTOR_SIZE = 8
+EMOTION_TYPE_SPEAKER = "speaker"
+EMOTION_TYPE_AUDIO = "audio"
+EMOTION_TYPE_VECTOR = "vector"
+EMOTION_TYPE_TEXT = "text"
+EMOTION_TYPE_CHOICES = [
+    (i18n("与音色参考相同"), EMOTION_TYPE_SPEAKER),
+    (i18n("情感参考音频"), EMOTION_TYPE_AUDIO),
+    (i18n("情感向量"), EMOTION_TYPE_VECTOR),
+    (i18n("情感描述文本"), EMOTION_TYPE_TEXT),
+]
+SPEAKER_TARGET_LABEL = i18n("对应音色参考")
+SPEAKER_TARGET_INFO = i18n("当存在多个音色参考时，请选择该情感行对应的音色参考。")
+EMOTION_VECTOR_LABELS = [
+    i18n("喜"),
+    i18n("怒"),
+    i18n("哀"),
+    i18n("惧"),
+    i18n("厌恶"),
+    i18n("低落"),
+    i18n("惊喜"),
+    i18n("平静"),
+]
 
-MAX_LENGTH_TO_USE_SPEED = 70
-example_cases = []
-with open("examples/cases.jsonl", "r", encoding="utf-8") as f:
-    for line in f:
-        line = line.strip()
-        if not line:
-            continue
-        example = json.loads(line)
-        if example.get("emo_audio",None):
-            emo_audio_path = os.path.join("examples",example["emo_audio"])
-        else:
-            emo_audio_path = None
+os.makedirs("outputs/tasks", exist_ok=True)
+os.makedirs("prompts", exist_ok=True)
+os.makedirs("logs", exist_ok=True)
+WEBUI_LOG_PATH = os.path.join("logs", "webui_runtime.log")
 
-        example_cases.append([os.path.join("examples", example.get("prompt_audio", "sample_prompt.wav")),
-                              EMO_CHOICES_ALL[example.get("emo_mode",0)],
-                              example.get("text"),
-                             emo_audio_path,
-                             example.get("emo_weight",1.0),
-                             example.get("emo_text",""),
-                             example.get("emo_vec_1",0),
-                             example.get("emo_vec_2",0),
-                             example.get("emo_vec_3",0),
-                             example.get("emo_vec_4",0),
-                             example.get("emo_vec_5",0),
-                             example.get("emo_vec_6",0),
-                             example.get("emo_vec_7",0),
-                             example.get("emo_vec_8",0),
-                             ])
-
-def get_example_cases(include_experimental = False):
-    if include_experimental:
-        return example_cases  # show every example
-
-    # exclude emotion control mode 3 (emotion from text description)
-    return [x for x in example_cases if x[1] != EMO_CHOICES_ALL[3]]
 
 def format_glossary_markdown():
-    """将词汇表转换为Markdown表格格式"""
     if not tts.normalizer.term_glossary:
         return i18n("暂无术语")
 
@@ -124,20 +112,298 @@ def format_glossary_markdown():
 
     return "\n".join(lines)
 
-def gen_single(emo_control_method,prompt, text,
-               emo_ref_path, emo_weight,
-               vec1, vec2, vec3, vec4, vec5, vec6, vec7, vec8,
-               emo_text,emo_random,
-               max_text_tokens_per_segment=120,
-                *args, progress=gr.Progress()):
-    output_path = None
-    if not output_path:
-        output_path = os.path.join("outputs", f"spk_{int(time.time())}.wav")
-    # set gradio progress
-    tts.gr_progress = progress
-    do_sample, top_p, top_k, temperature, \
-        length_penalty, num_beams, repetition_penalty, max_mel_tokens = args
-    kwargs = {
+
+def create_warning_message(warning_text):
+    return gr.HTML(
+        f"<div style=\"padding: 0.5em 0.8em; border-radius: 0.5em; background: #ffa87d; color: #000; font-weight: bold\">"
+        f"{html.escape(warning_text)}</div>"
+    )
+
+
+def create_error_message(error_text):
+    return (
+        "<div style=\"padding: 0.75em 0.9em; border-radius: 0.5em; "
+        "background: #ffe3e3; color: #8f1d1d; font-weight: 600; white-space: pre-wrap;\">"
+        f"{html.escape(i18n('生成失败'))}\n{html.escape(error_text)}</div>"
+    )
+
+
+def create_info_message(info_text):
+    return (
+        "<div style=\"padding: 0.75em 0.9em; border-radius: 0.5em; "
+        "background: #e7f1ff; color: #0f407a; font-weight: 600; white-space: pre-wrap;\">"
+        f"{html.escape(info_text)}</div>"
+    )
+
+
+def clamp_weight(value):
+    try:
+        return max(0.0, min(1.0, float(value)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def finalize_weights(weights, active_indices, anchor_index=None):
+    finalized = [0.0] * len(weights)
+    for index in active_indices:
+        finalized[index] = round(weights[index], 2)
+
+    target_sum = 1.0
+    current_sum = round(sum(finalized[index] for index in active_indices), 2)
+    delta = round(target_sum - current_sum, 2)
+    if abs(delta) < 1e-9:
+        return finalized
+
+    candidate_indices = []
+    if anchor_index is not None and anchor_index in active_indices:
+        candidate_indices.append(anchor_index)
+    candidate_indices.extend(index for index in reversed(active_indices) if index not in candidate_indices)
+
+    for index in candidate_indices:
+        updated = round(finalized[index] + delta, 2)
+        if 0.0 <= updated <= 1.0:
+            finalized[index] = updated
+            return finalized
+
+    fallback_index = active_indices[-1]
+    finalized[fallback_index] = round(max(0.0, min(1.0, finalized[fallback_index] + delta)), 2)
+    return finalized
+
+
+def rebalance_weights(active_flags, weights, anchor_index=None):
+    active_indices = [index for index, active in enumerate(active_flags) if bool(active)]
+    normalized = [0.0] * len(weights)
+    if not active_indices:
+        return normalized
+
+    if len(active_indices) == 1:
+        normalized[active_indices[0]] = 1.0
+        return normalized
+
+    raw_weights = [clamp_weight(weight) for weight in weights]
+    if anchor_index is not None and anchor_index in active_indices:
+        anchor_value = raw_weights[anchor_index]
+        remaining = max(0.0, 1.0 - anchor_value)
+        other_indices = [index for index in active_indices if index != anchor_index]
+        other_total = sum(raw_weights[index] for index in other_indices)
+        normalized[anchor_index] = anchor_value
+        if other_total > 0:
+            for index in other_indices:
+                normalized[index] = raw_weights[index] / other_total * remaining
+        else:
+            equal_share = remaining / len(other_indices)
+            for index in other_indices:
+                normalized[index] = equal_share
+    else:
+        total = sum(raw_weights[index] for index in active_indices)
+        if total > 0:
+            for index in active_indices:
+                normalized[index] = raw_weights[index] / total
+        else:
+            equal_share = 1.0 / len(active_indices)
+            for index in active_indices:
+                normalized[index] = equal_share
+
+    return finalize_weights(normalized, active_indices, anchor_index=anchor_index)
+
+
+def make_weight_updates(weights):
+    return [gr.update(value=value) for value in weights]
+
+
+def update_weights_for_slider(anchor_index, *values):
+    row_count = len(values) // 2
+    active_flags = list(values[:row_count])
+    weights = list(values[row_count:])
+    return make_weight_updates(rebalance_weights(active_flags, weights, anchor_index=anchor_index))
+
+
+def activate_next_row(*values):
+    row_count = len(values) // 2
+    active_flags = [bool(value) for value in values[:row_count]]
+    weights = list(values[row_count:])
+    for index, active in enumerate(active_flags):
+        if not active:
+            active_flags[index] = True
+            break
+    normalized = rebalance_weights(active_flags, weights)
+    updates = [gr.update(value=active) for active in active_flags]
+    updates.extend(gr.update(visible=active) for active in active_flags)
+    updates.extend(make_weight_updates(normalized))
+    return updates
+
+
+def remove_row(row_index, minimum_active, *values):
+    row_count = len(values) // 2
+    active_flags = [bool(value) for value in values[:row_count]]
+    weights = list(values[row_count:])
+    active_count = sum(active_flags)
+    if row_index < 0 or row_index >= row_count or not active_flags[row_index] or active_count <= minimum_active:
+        normalized = rebalance_weights(active_flags, weights)
+    else:
+        active_flags[row_index] = False
+        weights[row_index] = 0.0
+        normalized = rebalance_weights(active_flags, weights)
+
+    updates = [gr.update(value=active) for active in active_flags]
+    updates.extend(gr.update(visible=active) for active in active_flags)
+    updates.extend(make_weight_updates(normalized))
+    return active_flags, updates
+
+
+def emotion_type_visibility(row_type):
+    row_type = row_type or EMOTION_TYPE_SPEAKER
+    return (
+        gr.update(visible=row_type == EMOTION_TYPE_SPEAKER),
+        gr.update(visible=row_type == EMOTION_TYPE_AUDIO),
+        gr.update(visible=row_type == EMOTION_TYPE_VECTOR),
+        gr.update(visible=row_type == EMOTION_TYPE_TEXT),
+    )
+
+
+def reset_emotion_row(row_index, *values):
+    row_count = len(values) // 2
+    active_flags, updates = remove_row(row_index, 1, *values[: row_count * 2])
+    default_type = EMOTION_TYPE_SPEAKER if row_index == 0 else EMOTION_TYPE_AUDIO
+    row_defaults = [
+        gr.update(value=default_type),
+        gr.update(value=None),
+        gr.update(value=None),
+        gr.update(value=""),
+    ]
+    row_defaults.extend(gr.update(value=0.0) for _ in range(EMOTION_VECTOR_SIZE))
+    row_defaults.extend(
+        [
+            gr.update(visible=default_type == EMOTION_TYPE_SPEAKER),
+            gr.update(visible=default_type == EMOTION_TYPE_AUDIO),
+            gr.update(visible=False),
+            gr.update(visible=False),
+        ]
+    )
+    return updates + row_defaults
+
+
+
+
+def collect_speaker_references(values):
+    return collect_speaker_references_payload(values)
+
+
+def collect_emotion_references(values, synthesis_text):
+    return collect_emotion_references_payload(
+        values,
+        synthesis_text,
+        tts.normalize_emo_vec,
+        EMOTION_TYPE_SPEAKER,
+        EMOTION_TYPE_AUDIO,
+        EMOTION_TYPE_VECTOR,
+        EMOTION_TYPE_TEXT,
+    )
+
+
+def build_speaker_target_choices(values):
+    targets = list_speaker_reference_targets(values)
+    choices = []
+    for index, path in targets:
+        label = f"{i18n('音色参考')} {index + 1}"
+        filename = os.path.basename(path)
+        if filename:
+            label = f"{label}: {filename}"
+        choices.append((label, index))
+    return targets, choices
+
+
+def refresh_speaker_target_selectors(*values):
+    offset = 0
+    speaker_values = []
+    for _ in range(MAX_SPEAKER_ROWS):
+        speaker_values.append(
+            {
+                "active": values[offset],
+                "audio": values[offset + 1],
+            }
+        )
+        offset += 2
+
+    emotion_types = list(values[offset : offset + MAX_EMOTION_ROWS])
+    offset += MAX_EMOTION_ROWS
+    current_indices = list(values[offset : offset + MAX_EMOTION_ROWS])
+
+    targets, choices = build_speaker_target_choices(speaker_values)
+    valid_indices = {index for index, _ in targets}
+    default_value = targets[0][0] if targets else None
+    updates = []
+
+    for row_type, current_index in zip(emotion_types, current_indices):
+        selected = None
+        if current_index not in (None, ""):
+            try:
+                candidate = int(current_index)
+            except (TypeError, ValueError):
+                candidate = None
+            if candidate in valid_indices:
+                selected = candidate
+
+        if selected is None and row_type == EMOTION_TYPE_SPEAKER and default_value is not None:
+            selected = default_value
+
+        updates.append(
+            gr.update(
+                choices=choices,
+                value=selected,
+                interactive=bool(targets),
+            )
+        )
+
+    return updates
+
+
+def parse_generation_inputs(raw_values):
+    offset = 0
+    text = raw_values[offset]
+    offset += 1
+    emo_random = raw_values[offset]
+    offset += 1
+    max_text_tokens_per_segment = raw_values[offset]
+    offset += 1
+
+    do_sample = raw_values[offset]
+    top_p = raw_values[offset + 1]
+    top_k = raw_values[offset + 2]
+    temperature = raw_values[offset + 3]
+    length_penalty = raw_values[offset + 4]
+    num_beams = raw_values[offset + 5]
+    repetition_penalty = raw_values[offset + 6]
+    max_mel_tokens = raw_values[offset + 7]
+    offset += 8
+
+    speaker_values = []
+    for _ in range(MAX_SPEAKER_ROWS):
+        speaker_values.append(
+            {
+                "active": raw_values[offset],
+                "audio": raw_values[offset + 1],
+                "weight": raw_values[offset + 2],
+            }
+        )
+        offset += 3
+
+    emotion_values = []
+    for _ in range(MAX_EMOTION_ROWS):
+        emotion_values.append(
+            {
+                "active": raw_values[offset],
+                "type": raw_values[offset + 1],
+                "speaker_index": raw_values[offset + 2],
+                "audio": raw_values[offset + 3],
+                "text": raw_values[offset + 4],
+                "weight": raw_values[offset + 5],
+                "vector": list(raw_values[offset + 6 : offset + 6 + EMOTION_VECTOR_SIZE]),
+            }
+        )
+        offset += 6 + EMOTION_VECTOR_SIZE
+
+    generation_kwargs = {
         "do_sample": bool(do_sample),
         "top_p": float(top_p),
         "top_k": int(top_k) if int(top_k) > 0 else None,
@@ -146,149 +412,308 @@ def gen_single(emo_control_method,prompt, text,
         "num_beams": num_beams,
         "repetition_penalty": float(repetition_penalty),
         "max_mel_tokens": int(max_mel_tokens),
-        # "typical_sampling": bool(typical_sampling),
-        # "typical_mass": float(typical_mass),
     }
-    if type(emo_control_method) is not int:
-        emo_control_method = emo_control_method.value
-    if emo_control_method == 0:  # emotion from speaker
-        emo_ref_path = None  # remove external reference audio
-    if emo_control_method == 1:  # emotion from reference audio
-        pass
-    if emo_control_method == 2:  # emotion from custom vectors
-        vec = [vec1, vec2, vec3, vec4, vec5, vec6, vec7, vec8]
-        vec = tts.normalize_emo_vec(vec, apply_bias=True)
+
+    return {
+        "text": text,
+        "emo_random": emo_random,
+        "max_text_tokens_per_segment": int(max_text_tokens_per_segment),
+        "speaker_values": speaker_values,
+        "emotion_values": emotion_values,
+        "generation_kwargs": generation_kwargs,
+    }
+
+
+def gen_single(*raw_values, progress=gr.Progress()):
+    try:
+        parsed = parse_generation_inputs(raw_values)
+        text = parsed["text"]
+        output_path = os.path.join("outputs", f"spk_{int(time.time())}.wav")
+        tts.gr_progress = progress
+
+        speaker_refs, speaker_weights = collect_speaker_references(parsed["speaker_values"])
+        emotion_references = collect_emotion_references(parsed["emotion_values"], text)
+
+        output = tts.infer(
+            spk_audio_prompt=speaker_refs,
+            text=text,
+            output_path=output_path,
+            emo_alpha=1.0,
+            spk_audio_weights=speaker_weights,
+            emotion_references=emotion_references,
+            use_random=parsed["emo_random"],
+            verbose=cmd_args.verbose,
+            max_text_tokens_per_segment=parsed["max_text_tokens_per_segment"],
+            **parsed["generation_kwargs"],
+        )
+        if output is None:
+            raise RuntimeError("Generation completed without producing an audio file.")
+        return (
+            gr.update(value=output, visible=True),
+            gr.update(value="", visible=False),
+        )
+    except Exception as exc:
+        error_message = f"{type(exc).__name__}: {exc}\nSee {WEBUI_LOG_PATH} for full details."
+        print("WebUI generation failed:")
+        traceback.print_exc()
+        with open(WEBUI_LOG_PATH, "a", encoding="utf-8") as handle:
+            handle.write(f"\n[{time.strftime('%Y-%m-%d %H:%M:%S')}] {error_message}\n")
+            handle.write(traceback.format_exc())
+            handle.write("\n")
+        return (
+            gr.update(value=None, visible=False),
+            gr.update(value=create_error_message(error_message), visible=True),
+        )
+
+
+def prepare_generation():
+    return (
+        gr.update(value=None, visible=False),
+        gr.update(value=create_info_message(i18n("Generating audio, please wait...")), visible=True),
+    )
+
+
+def on_input_text_change(text, max_text_tokens_per_segment):
+    if text:
+        text_tokens_list = tts.tokenizer.tokenize(text)
+        segments = tts.tokenizer.split_segments(
+            text_tokens_list,
+            max_text_tokens_per_segment=int(max_text_tokens_per_segment),
+        )
+        data = []
+        for index, segment in enumerate(segments):
+            data.append([index, "".join(segment), len(segment)])
+        return {segments_preview: gr.update(value=data, visible=True, type="array")}
+
+    df = pd.DataFrame([], columns=[i18n("序号"), i18n("分句内容"), i18n("Token数")])
+    return {segments_preview: gr.update(value=df)}
+
+
+def on_add_glossary_term(term, reading_zh, reading_en):
+    term = term.rstrip()
+    reading_zh = reading_zh.rstrip()
+    reading_en = reading_en.rstrip()
+
+    if not term:
+        gr.Warning(i18n("请输入术语"))
+        return gr.update()
+
+    if not reading_zh and not reading_en:
+        gr.Warning(i18n("请至少输入一种读法"))
+        return gr.update()
+
+    if reading_zh and reading_en:
+        reading = {"zh": reading_zh, "en": reading_en}
+    elif reading_zh:
+        reading = {"zh": reading_zh}
     else:
-        # don't use the emotion vector inputs for the other modes
-        vec = None
+        reading = {"en": reading_en}
 
-    if emo_text == "":
-        # erase empty emotion descriptions; `infer()` will then automatically use the main prompt
-        emo_text = None
+    tts.normalizer.term_glossary[term] = reading
 
-    print(f"Emo control mode:{emo_control_method},weight:{emo_weight},vec:{vec}")
-    output = tts.infer(spk_audio_prompt=prompt, text=text,
-                       output_path=output_path,
-                       emo_audio_prompt=emo_ref_path, emo_alpha=emo_weight,
-                       emo_vector=vec,
-                       use_emo_text=(emo_control_method==3), emo_text=emo_text,use_random=emo_random,
-                       verbose=cmd_args.verbose,
-                       max_text_tokens_per_segment=int(max_text_tokens_per_segment),
-                       **kwargs)
-    return gr.update(value=output,visible=True)
+    try:
+        tts.normalizer.save_glossary_to_yaml(tts.glossary_path)
+        gr.Info(i18n("词汇表已更新"), duration=1)
+    except Exception as exc:
+        gr.Error(i18n("保存词汇表时出错"))
+        print(f"Error details: {exc}")
+        return gr.update()
 
-def update_prompt_audio():
-    update_button = gr.update(interactive=True)
-    return update_button
+    return gr.update(value=format_glossary_markdown())
 
-def create_warning_message(warning_text):
-    return gr.HTML(f"<div style=\"padding: 0.5em 0.8em; border-radius: 0.5em; background: #ffa87d; color: #000; font-weight: bold\">{html.escape(warning_text)}</div>")
 
-def create_experimental_warning_message():
-    return create_warning_message(i18n('提示：此功能为实验版，结果尚不稳定，我们正在持续优化中。'))
+def on_glossary_checkbox_change(is_enabled):
+    tts.normalizer.enable_glossary = is_enabled
+    return gr.update(visible=is_enabled)
+
+
+def on_demo_load():
+    try:
+        tts.normalizer.load_glossary_from_yaml(tts.glossary_path)
+    except Exception as exc:
+        gr.Error(i18n("加载词汇表时出错"))
+        print(f"Failed to reload glossary on page load: {exc}")
+    return gr.update(value=format_glossary_markdown())
+
+
+speaker_rows = []
+emotion_rows = []
 
 with gr.Blocks(title="IndexTTS Demo") as demo:
-    mutex = threading.Lock()
-    gr.HTML('''
+    gr.HTML(
+        """
     <h2><center>IndexTTS2: A Breakthrough in Emotionally Expressive and Duration-Controlled Auto-Regressive Zero-Shot Text-to-Speech</h2>
 <p align="center">
 <a href='https://arxiv.org/abs/2506.21619'><img src='https://img.shields.io/badge/ArXiv-2506.21619-red'></a>
 </p>
-    ''')
+    """
+    )
 
     with gr.Tab(i18n("音频生成")):
         with gr.Row():
-            os.makedirs("prompts",exist_ok=True)
-            prompt_audio = gr.Audio(label=i18n("音色参考音频"),key="prompt_audio",
-                                    sources=["upload","microphone"],type="filepath")
-            prompt_list = os.listdir("prompts")
-            default = ''
-            if prompt_list:
-                default = prompt_list[0]
-            with gr.Column():
-                input_text_single = gr.TextArea(label=i18n("文本"),key="input_text_single", placeholder=i18n("请输入目标文本"), info=f"{i18n('当前模型版本')}{tts.model_version or '1.0'}")
-                gen_button = gr.Button(i18n("生成语音"), key="gen_button",interactive=True)
-            output_audio = gr.Audio(label=i18n("生成结果"), visible=True,key="output_audio")
+            input_text_single = gr.TextArea(
+                label=i18n("文本"),
+                key="input_text_single",
+                placeholder=i18n("请输入目标文本"),
+                info=f"{i18n('当前模型版本')}{tts.model_version or '1.0'}",
+            )
+            output_audio = gr.Audio(label=i18n("生成结果"), visible=True, key="output_audio")
 
-        with gr.Row():
-            experimental_checkbox = gr.Checkbox(label=i18n("显示实验功能"), value=False)
-            glossary_checkbox = gr.Checkbox(label=i18n("开启术语词汇读音"), value=tts.normalizer.enable_glossary)
-        with gr.Accordion(i18n("功能设置")):
-            # 情感控制选项部分
-            with gr.Row():
-                emo_control_method = gr.Radio(
-                    choices=EMO_CHOICES_OFFICIAL,
-                    type="index",
-                    value=EMO_CHOICES_OFFICIAL[0],label=i18n("情感控制方式"))
-                # we MUST have an extra, INVISIBLE list of *all* emotion control
-                # methods so that gr.Dataset() can fetch ALL control mode labels!
-                # otherwise, the gr.Dataset()'s experimental labels would be empty!
-                emo_control_method_all = gr.Radio(
-                    choices=EMO_CHOICES_ALL,
-                    type="index",
-                    value=EMO_CHOICES_ALL[0], label=i18n("情感控制方式"),
-                    visible=False)  # do not render
-        # 情感参考音频部分
-        with gr.Group(visible=False) as emotion_reference_group:
-            with gr.Row():
-                emo_upload = gr.Audio(label=i18n("上传情感参考音频"), type="filepath")
+        gen_button = gr.Button(i18n("生成语音"), key="gen_button", interactive=True, variant="primary")
+        generation_status = gr.HTML(value="", visible=False)
 
-        # 情感随机采样
-        with gr.Row(visible=False) as emotion_randomize_group:
+        with gr.Accordion(i18n("音色参考音频"), open=True):
+            gr.Markdown(i18n("多参考音色按权重归一化融合。拖动任一滑块时，其余行会自动调整以保持总和为 1。"))
+            gr.HTML(
+                """
+                <div style="display:flex; gap:12px; font-weight:600; margin-bottom:8px;">
+                    <div style="flex:4;">音频</div>
+                    <div style="flex:2;">权重</div>
+                    <div style="width:88px;">操作</div>
+                </div>
+                """
+            )
+            for index in range(MAX_SPEAKER_ROWS):
+                active = index == 0
+                with gr.Group(visible=active) as row_group:
+                    with gr.Row():
+                        row_audio = gr.Audio(
+                            label=f"{i18n('音色参考')} {index + 1}",
+                            sources=["upload", "microphone"],
+                            type="filepath",
+                        )
+                        row_weight = gr.Slider(
+                            label=i18n("权重"),
+                            minimum=0.0,
+                            maximum=1.0,
+                            value=1.0 if active else 0.0,
+                            step=0.01,
+                        )
+                        row_remove = gr.Button(i18n("移除"), interactive=index > 0)
+                row_active = gr.Checkbox(value=active, visible=False)
+                speaker_rows.append(
+                    {
+                        "active": row_active,
+                        "group": row_group,
+                        "audio": row_audio,
+                        "weight": row_weight,
+                        "remove": row_remove,
+                    }
+                )
+            speaker_add_button = gr.Button(i18n("添加音色参考"))
+
+        with gr.Accordion(i18n("情感参考"), open=True):
+            create_warning_message(i18n("情感行支持与音色参考、参考音频、情感向量、情感文本混合融合，所有权重统一归一化。"))
+            gr.HTML(
+                """
+                <div style="display:flex; gap:12px; font-weight:600; margin-bottom:8px;">
+                    <div style="width:180px;">类型</div>
+                    <div style="flex:4;">输入</div>
+                    <div style="flex:2;">权重</div>
+                    <div style="width:88px;">操作</div>
+                </div>
+                """
+            )
+            for index in range(MAX_EMOTION_ROWS):
+                active = index == 0
+                default_type = EMOTION_TYPE_SPEAKER if index == 0 else EMOTION_TYPE_AUDIO
+                with gr.Group(visible=active) as row_group:
+                    with gr.Row():
+                        row_type = gr.Dropdown(
+                            label=i18n("输入类型"),
+                            choices=EMOTION_TYPE_CHOICES,
+                            value=default_type,
+                        )
+                        with gr.Column(scale=4):
+                            with gr.Group(visible=default_type == EMOTION_TYPE_SPEAKER) as speaker_group:
+                                row_speaker_index = gr.Dropdown(
+                                    label=SPEAKER_TARGET_LABEL,
+                                    info=SPEAKER_TARGET_INFO,
+                                    choices=[],
+                                    value=None,
+                                    allow_custom_value=False,
+                                )
+                            with gr.Group(visible=default_type == EMOTION_TYPE_AUDIO) as audio_group:
+                                row_audio = gr.Audio(
+                                    label=f"{i18n('情感参考音频')} {index + 1}",
+                                    sources=["upload", "microphone"],
+                                    type="filepath",
+                                )
+                            with gr.Group(visible=False) as vector_group:
+                                vector_components = []
+                                for vector_offset, label in enumerate(EMOTION_VECTOR_LABELS):
+                                    vector_components.append(
+                                        gr.Slider(
+                                            label=label,
+                                            minimum=0.0,
+                                            maximum=1.0,
+                                            value=0.0,
+                                            step=0.05,
+                                        )
+                                    )
+                            with gr.Group(visible=False) as text_group:
+                                row_text = gr.Textbox(
+                                    label=i18n("情感描述文本"),
+                                    placeholder=i18n("留空时自动使用目标文本"),
+                                    value="",
+                                )
+                        row_weight = gr.Slider(
+                            label=i18n("权重"),
+                            minimum=0.0,
+                            maximum=1.0,
+                            value=1.0 if active else 0.0,
+                            step=0.01,
+                        )
+                        row_remove = gr.Button(i18n("移除"), interactive=index > 0)
+                row_active = gr.Checkbox(value=active, visible=False)
+                emotion_rows.append(
+                    {
+                        "active": row_active,
+                        "group": row_group,
+                        "type": row_type,
+                        "speaker_group": speaker_group,
+                        "speaker_index": row_speaker_index,
+                        "audio_group": audio_group,
+                        "vector_group": vector_group,
+                        "text_group": text_group,
+                        "audio": row_audio,
+                        "text": row_text,
+                        "vector": vector_components,
+                        "weight": row_weight,
+                        "remove": row_remove,
+                    }
+                )
+            emotion_add_button = gr.Button(i18n("添加情感参考"))
             emo_random = gr.Checkbox(label=i18n("情感随机采样"), value=False)
 
-        # 情感向量控制部分
-        with gr.Group(visible=False) as emotion_vector_group:
-            with gr.Row():
-                with gr.Column():
-                    vec1 = gr.Slider(label=i18n("喜"), minimum=0.0, maximum=1.0, value=0.0, step=0.05)
-                    vec2 = gr.Slider(label=i18n("怒"), minimum=0.0, maximum=1.0, value=0.0, step=0.05)
-                    vec3 = gr.Slider(label=i18n("哀"), minimum=0.0, maximum=1.0, value=0.0, step=0.05)
-                    vec4 = gr.Slider(label=i18n("惧"), minimum=0.0, maximum=1.0, value=0.0, step=0.05)
-                with gr.Column():
-                    vec5 = gr.Slider(label=i18n("厌恶"), minimum=0.0, maximum=1.0, value=0.0, step=0.05)
-                    vec6 = gr.Slider(label=i18n("低落"), minimum=0.0, maximum=1.0, value=0.0, step=0.05)
-                    vec7 = gr.Slider(label=i18n("惊喜"), minimum=0.0, maximum=1.0, value=0.0, step=0.05)
-                    vec8 = gr.Slider(label=i18n("平静"), minimum=0.0, maximum=1.0, value=0.0, step=0.05)
+        with gr.Row():
+            glossary_checkbox = gr.Checkbox(
+                label=i18n("开启术语词汇读音"),
+                value=tts.normalizer.enable_glossary,
+            )
 
-        with gr.Group(visible=False) as emo_text_group:
-            create_experimental_warning_message()
-            with gr.Row():
-                emo_text = gr.Textbox(label=i18n("情感描述文本"),
-                                      placeholder=i18n("请输入情绪描述（或留空以自动使用目标文本作为情绪描述）"),
-                                      value="",
-                                      info=i18n("例如：委屈巴巴、危险在悄悄逼近"))
-
-        with gr.Row(visible=False) as emo_weight_group:
-            emo_weight = gr.Slider(label=i18n("情感权重"), minimum=0.0, maximum=1.0, value=0.65, step=0.01)
-
-        # 术语词汇表管理
-        with gr.Accordion(i18n("自定义术语词汇读音"), open=False, visible=tts.normalizer.enable_glossary) as glossary_accordion:
+        with gr.Accordion(
+            i18n("自定义术语词汇读音"),
+            open=False,
+            visible=tts.normalizer.enable_glossary,
+        ) as glossary_accordion:
             gr.Markdown(i18n("自定义个别专业术语的读音"))
             with gr.Row():
                 with gr.Column(scale=1):
-                    glossary_term = gr.Textbox(
-                        label=i18n("术语"),
-                        placeholder="IndexTTS2",
-                    )
-                    glossary_reading_zh = gr.Textbox(
-                        label=i18n("中文读法"),
-                        placeholder="Index T-T-S 二",
-                    )
-                    glossary_reading_en = gr.Textbox(
-                        label=i18n("英文读法"),
-                        placeholder="Index T-T-S two",
-                    )
+                    glossary_term = gr.Textbox(label=i18n("术语"), placeholder="IndexTTS2")
+                    glossary_reading_zh = gr.Textbox(label=i18n("中文读法"), placeholder="Index T-T-S 二")
+                    glossary_reading_en = gr.Textbox(label=i18n("英文读法"), placeholder="Index T-T-S two")
                     btn_add_term = gr.Button(i18n("添加术语"), scale=1)
                 with gr.Column(scale=2):
-                    glossary_table = gr.Markdown(
-                        value=format_glossary_markdown()
-                    )
+                    glossary_table = gr.Markdown(value=format_glossary_markdown())
 
-        with gr.Accordion(i18n("高级生成参数设置"), open=False, visible=True) as advanced_settings_group:
+        with gr.Accordion(i18n("高级生成参数设置"), open=False, visible=True):
             with gr.Row():
                 with gr.Column(scale=1):
-                    gr.Markdown(f"**{i18n('GPT2 采样设置')}** _{i18n('参数会影响音频多样性和生成速度详见')} [Generation strategies](https://huggingface.co/docs/transformers/main/en/generation_strategies)._")
+                    gr.Markdown(
+                        f"**{i18n('GPT2 采样设置')}** _{i18n('参数会影响音频多样性和生成速度详见')} "
+                        "[Generation strategies](https://huggingface.co/docs/transformers/main/en/generation_strategies)._"
+                    )
                     with gr.Row():
                         do_sample = gr.Checkbox(label="do_sample", value=True, info=i18n("是否进行采样"))
                         temperature = gr.Slider(label="temperature", minimum=0.1, maximum=2.0, value=0.8, step=0.1)
@@ -297,259 +722,205 @@ with gr.Blocks(title="IndexTTS Demo") as demo:
                         top_k = gr.Slider(label="top_k", minimum=0, maximum=100, value=30, step=1)
                         num_beams = gr.Slider(label="num_beams", value=3, minimum=1, maximum=10, step=1)
                     with gr.Row():
-                        repetition_penalty = gr.Number(label="repetition_penalty", precision=None, value=10.0, minimum=0.1, maximum=20.0, step=0.1)
-                        length_penalty = gr.Number(label="length_penalty", precision=None, value=0.0, minimum=-2.0, maximum=2.0, step=0.1)
-                    max_mel_tokens = gr.Slider(label="max_mel_tokens", value=1500, minimum=50, maximum=tts.cfg.gpt.max_mel_tokens, step=10, info=i18n("生成Token最大数量，过小导致音频被截断"), key="max_mel_tokens")
-                    # with gr.Row():
-                    #     typical_sampling = gr.Checkbox(label="typical_sampling", value=False, info="不建议使用")
-                    #     typical_mass = gr.Slider(label="typical_mass", value=0.9, minimum=0.0, maximum=1.0, step=0.1)
-                with gr.Column(scale=2):
-                    gr.Markdown(f'**{i18n("分句设置")}** _{i18n("参数会影响音频质量和生成速度")}_')
-                    with gr.Row():
-                        initial_value = max(20, min(tts.cfg.gpt.max_text_tokens, cmd_args.gui_seg_tokens))
-                        max_text_tokens_per_segment = gr.Slider(
-                            label=i18n("分句最大Token数"), value=initial_value, minimum=20, maximum=tts.cfg.gpt.max_text_tokens, step=2, key="max_text_tokens_per_segment",
-                            info=i18n("建议80~200之间，值越大，分句越长；值越小，分句越碎；过小过大都可能导致音频质量不高"),
+                        repetition_penalty = gr.Number(
+                            label="repetition_penalty",
+                            precision=None,
+                            value=10.0,
+                            minimum=0.1,
+                            maximum=20.0,
+                            step=0.1,
                         )
-                    with gr.Accordion(i18n("预览分句结果"), open=True) as segments_settings:
+                        length_penalty = gr.Number(
+                            label="length_penalty",
+                            precision=None,
+                            value=0.0,
+                            minimum=-2.0,
+                            maximum=2.0,
+                            step=0.1,
+                        )
+                    max_mel_tokens = gr.Slider(
+                        label="max_mel_tokens",
+                        value=1500,
+                        minimum=50,
+                        maximum=tts.cfg.gpt.max_mel_tokens,
+                        step=10,
+                        info=i18n("生成Token最大数量，过小导致音频被截断"),
+                    )
+                with gr.Column(scale=2):
+                    gr.Markdown(f"**{i18n('分句设置')}** _{i18n('参数会影响音频质量和生成速度')}_")
+                    initial_value = max(20, min(tts.cfg.gpt.max_text_tokens, cmd_args.gui_seg_tokens))
+                    max_text_tokens_per_segment = gr.Slider(
+                        label=i18n("分句最大Token数"),
+                        value=initial_value,
+                        minimum=20,
+                        maximum=tts.cfg.gpt.max_text_tokens,
+                        step=2,
+                        info=i18n("建议80~200之间，值越大分句越长；值越小分句越碎。"),
+                    )
+                    with gr.Accordion(i18n("预览分句结果"), open=True):
                         segments_preview = gr.Dataframe(
                             headers=[i18n("序号"), i18n("分句内容"), i18n("Token数")],
                             key="segments_preview",
                             wrap=True,
                         )
-            advanced_params = [
-                do_sample, top_p, top_k, temperature,
-                length_penalty, num_beams, repetition_penalty, max_mel_tokens,
-                # typical_sampling, typical_mass,
-            ]
 
-        # we must use `gr.Dataset` to support dynamic UI rewrites, since `gr.Examples`
-        # binds tightly to UI and always restores the initial state of all components,
-        # such as the list of available choices in emo_control_method.
-        example_table = gr.Dataset(label="Examples",
-            samples_per_page=20,
-            samples=get_example_cases(include_experimental=False),
-            type="values",
-            # these components are NOT "connected". it just reads the column labels/available
-            # states from them, so we MUST link to the "all options" versions of all components,
-            # such as `emo_control_method_all` (to be able to see EXPERIMENTAL text labels)!
-            components=[prompt_audio,
-                        emo_control_method_all,  # important: support all mode labels!
-                        input_text_single,
-                        emo_upload,
-                        emo_weight,
-                        emo_text,
-                        vec1, vec2, vec3, vec4, vec5, vec6, vec7, vec8]
+    speaker_active_inputs = [row["active"] for row in speaker_rows]
+    speaker_weight_inputs = [row["weight"] for row in speaker_rows]
+    speaker_visibility_outputs = [row["group"] for row in speaker_rows]
+    speaker_weight_outputs = [row["weight"] for row in speaker_rows]
+    speaker_management_outputs = speaker_active_inputs + speaker_visibility_outputs + speaker_weight_outputs
+
+    emotion_active_inputs = [row["active"] for row in emotion_rows]
+    emotion_weight_inputs = [row["weight"] for row in emotion_rows]
+    emotion_visibility_outputs = [row["group"] for row in emotion_rows]
+    emotion_weight_outputs = [row["weight"] for row in emotion_rows]
+    emotion_management_outputs = emotion_active_inputs + emotion_visibility_outputs + emotion_weight_outputs
+    speaker_selector_refresh_inputs = []
+    for row in speaker_rows:
+        speaker_selector_refresh_inputs.extend([row["active"], row["audio"]])
+    emotion_type_inputs = [row["type"] for row in emotion_rows]
+    emotion_speaker_index_inputs = [row["speaker_index"] for row in emotion_rows]
+    speaker_selector_refresh_inputs.extend(emotion_type_inputs)
+    speaker_selector_refresh_inputs.extend(emotion_speaker_index_inputs)
+    speaker_selector_outputs = emotion_speaker_index_inputs
+
+    for index, row in enumerate(speaker_rows):
+        row["weight"].change(
+            lambda *values, row_index=index: update_weights_for_slider(row_index, *values),
+            inputs=speaker_active_inputs + speaker_weight_inputs,
+            outputs=speaker_weight_outputs,
+        )
+        row["audio"].change(
+            refresh_speaker_target_selectors,
+            inputs=speaker_selector_refresh_inputs,
+            outputs=speaker_selector_outputs,
         )
 
-    def on_example_click(example):
-        print(f"Example clicked: ({len(example)} values) = {example!r}")
-        return (
-            gr.update(value=example[0]),
-            gr.update(value=example[1]),
-            gr.update(value=example[2]),
-            gr.update(value=example[3]),
-            gr.update(value=example[4]),
-            gr.update(value=example[5]),
-            gr.update(value=example[6]),
-            gr.update(value=example[7]),
-            gr.update(value=example[8]),
-            gr.update(value=example[9]),
-            gr.update(value=example[10]),
-            gr.update(value=example[11]),
-            gr.update(value=example[12]),
-            gr.update(value=example[13]),
+    speaker_add_button.click(
+        activate_next_row,
+        inputs=speaker_active_inputs + speaker_weight_inputs,
+        outputs=speaker_management_outputs,
+    ).then(
+        refresh_speaker_target_selectors,
+        inputs=speaker_selector_refresh_inputs,
+        outputs=speaker_selector_outputs,
+    )
+
+    for index, row in enumerate(speaker_rows[1:], start=1):
+        row["remove"].click(
+            lambda *values, row_index=index: remove_row(row_index, 1, *values)[1] + [gr.update(value=None)],
+            inputs=speaker_active_inputs + speaker_weight_inputs,
+            outputs=speaker_management_outputs + [row["audio"]],
+        ).then(
+            refresh_speaker_target_selectors,
+            inputs=speaker_selector_refresh_inputs,
+            outputs=speaker_selector_outputs,
         )
 
-    # click() event works on both desktop and mobile UI
-    example_table.click(on_example_click,
-                        inputs=[example_table],
-                        outputs=[prompt_audio,
-                                 emo_control_method,
-                                 input_text_single,
-                                 emo_upload,
-                                 emo_weight,
-                                 emo_text,
-                                 vec1, vec2, vec3, vec4, vec5, vec6, vec7, vec8]
-    )
-
-    def on_input_text_change(text, max_text_tokens_per_segment):
-        if text and len(text) > 0:
-            text_tokens_list = tts.tokenizer.tokenize(text)
-
-            segments = tts.tokenizer.split_segments(text_tokens_list, max_text_tokens_per_segment=int(max_text_tokens_per_segment))
-            data = []
-            for i, s in enumerate(segments):
-                segment_str = ''.join(s)
-                tokens_count = len(s)
-                data.append([i, segment_str, tokens_count])
-            return {
-                segments_preview: gr.update(value=data, visible=True, type="array"),
-            }
-        else:
-            df = pd.DataFrame([], columns=[i18n("序号"), i18n("分句内容"), i18n("Token数")])
-            return {
-                segments_preview: gr.update(value=df),
-            }
-
-    # 术语词汇表事件处理函数
-    def on_add_glossary_term(term, reading_zh, reading_en):
-        """添加术语到词汇表并自动保存"""
-        term = term.rstrip()
-        reading_zh = reading_zh.rstrip()
-        reading_en = reading_en.rstrip()
-
-        if not term:
-            gr.Warning(i18n("请输入术语"))
-            return gr.update()
-            
-        if not reading_zh and not reading_en:
-            gr.Warning(i18n("请至少输入一种读法"))
-            return gr.update()
-        
-
-        # 构建读法数据
-        if reading_zh and reading_en:
-            reading = {"zh": reading_zh, "en": reading_en}
-        elif reading_zh:
-            reading = {"zh": reading_zh}
-        elif reading_en:
-            reading = {"en": reading_en}
-        else:
-            reading = reading_zh or reading_en
-
-        # 添加到词汇表
-        tts.normalizer.term_glossary[term] = reading
-
-        # 自动保存到文件
-        try:
-            tts.normalizer.save_glossary_to_yaml(tts.glossary_path)
-            gr.Info(i18n("词汇表已更新"), duration=1)
-        except Exception as e:
-            gr.Error(i18n("保存词汇表时出错"))
-            print(f"Error details: {e}")
-            return gr.update()
-
-        # 更新Markdown表格
-        return gr.update(value=format_glossary_markdown())
-        
-
-    def on_method_change(emo_control_method):
-        if emo_control_method == 1:  # emotion reference audio
-            return (gr.update(visible=True),
-                    gr.update(visible=False),
-                    gr.update(visible=False),
-                    gr.update(visible=False),
-                    gr.update(visible=True)
-                    )
-        elif emo_control_method == 2:  # emotion vectors
-            return (gr.update(visible=False),
-                    gr.update(visible=True),
-                    gr.update(visible=True),
-                    gr.update(visible=False),
-                    gr.update(visible=True)
-                    )
-        elif emo_control_method == 3:  # emotion text description
-            return (gr.update(visible=False),
-                    gr.update(visible=True),
-                    gr.update(visible=False),
-                    gr.update(visible=True),
-                    gr.update(visible=True)
-                    )
-        else:  # 0: same as speaker voice
-            return (gr.update(visible=False),
-                    gr.update(visible=False),
-                    gr.update(visible=False),
-                    gr.update(visible=False),
-                    gr.update(visible=False)
-                    )
-
-    emo_control_method.change(on_method_change,
-        inputs=[emo_control_method],
-        outputs=[emotion_reference_group,
-                 emotion_randomize_group,
-                 emotion_vector_group,
-                 emo_text_group,
-                 emo_weight_group]
-    )
-
-    def on_experimental_change(is_experimental, current_mode_index):
-        # 切换情感控制选项
-        new_choices = EMO_CHOICES_ALL if is_experimental else EMO_CHOICES_OFFICIAL
-        # if their current mode selection doesn't exist in new choices, reset to 0.
-        # we don't verify that OLD index means the same in NEW list, since we KNOW it does.
-        new_index = current_mode_index if current_mode_index < len(new_choices) else 0
-
-        return (
-            gr.update(choices=new_choices, value=new_choices[new_index]),
-            gr.update(samples=get_example_cases(include_experimental=is_experimental)),
+    for index, row in enumerate(emotion_rows):
+        row["weight"].change(
+            lambda *values, row_index=index: update_weights_for_slider(row_index, *values),
+            inputs=emotion_active_inputs + emotion_weight_inputs,
+            outputs=emotion_weight_outputs,
+        )
+        row["type"].change(
+            emotion_type_visibility,
+            inputs=[row["type"]],
+            outputs=[row["speaker_group"], row["audio_group"], row["vector_group"], row["text_group"]],
+        ).then(
+            refresh_speaker_target_selectors,
+            inputs=speaker_selector_refresh_inputs,
+            outputs=speaker_selector_outputs,
         )
 
-    experimental_checkbox.change(
-        on_experimental_change,
-        inputs=[experimental_checkbox, emo_control_method],
-        outputs=[emo_control_method, example_table]
+    emotion_add_button.click(
+        activate_next_row,
+        inputs=emotion_active_inputs + emotion_weight_inputs,
+        outputs=emotion_management_outputs,
+    ).then(
+        refresh_speaker_target_selectors,
+        inputs=speaker_selector_refresh_inputs,
+        outputs=speaker_selector_outputs,
     )
 
-    def on_glossary_checkbox_change(is_enabled):
-        """控制术语词汇表的可见性"""
-        tts.normalizer.enable_glossary = is_enabled
-        return gr.update(visible=is_enabled)
-
-    glossary_checkbox.change(
-        on_glossary_checkbox_change,
-        inputs=[glossary_checkbox],
-        outputs=[glossary_accordion]
-    )
+    for index, row in enumerate(emotion_rows[1:], start=1):
+        row["remove"].click(
+            lambda *values, row_index=index: reset_emotion_row(row_index, *values),
+            inputs=emotion_active_inputs + emotion_weight_inputs,
+            outputs=emotion_management_outputs
+            + [row["type"], row["speaker_index"], row["audio"], row["text"]]
+            + row["vector"]
+            + [row["speaker_group"], row["audio_group"], row["vector_group"], row["text_group"]],
+        ).then(
+            refresh_speaker_target_selectors,
+            inputs=speaker_selector_refresh_inputs,
+            outputs=speaker_selector_outputs,
+        )
 
     input_text_single.change(
         on_input_text_change,
         inputs=[input_text_single, max_text_tokens_per_segment],
-        outputs=[segments_preview]
+        outputs=[segments_preview],
     )
 
     max_text_tokens_per_segment.change(
         on_input_text_change,
         inputs=[input_text_single, max_text_tokens_per_segment],
-        outputs=[segments_preview]
+        outputs=[segments_preview],
     )
 
-    prompt_audio.upload(update_prompt_audio,
-                         inputs=[],
-                         outputs=[gen_button])
-
-    def on_demo_load():
-        """页面加载时重新加载glossary数据"""
-        try:
-            tts.normalizer.load_glossary_from_yaml(tts.glossary_path)
-        except Exception as e:
-            gr.Error(i18n("加载词汇表时出错"))
-            print(f"Failed to reload glossary on page load: {e}")
-        return gr.update(value=format_glossary_markdown())
-
-    # 术语词汇表事件绑定
     btn_add_term.click(
         on_add_glossary_term,
         inputs=[glossary_term, glossary_reading_zh, glossary_reading_en],
-        outputs=[glossary_table]
+        outputs=[glossary_table],
     )
 
-    # 页面加载时重新加载glossary
+    glossary_checkbox.change(
+        on_glossary_checkbox_change,
+        inputs=[glossary_checkbox],
+        outputs=[glossary_accordion],
+    )
+
     demo.load(
         on_demo_load,
         inputs=[],
-        outputs=[glossary_table]
+        outputs=[glossary_table],
+    )
+    demo.load(
+        refresh_speaker_target_selectors,
+        inputs=speaker_selector_refresh_inputs,
+        outputs=speaker_selector_outputs,
     )
 
-    gen_button.click(gen_single,
-                     inputs=[emo_control_method,prompt_audio, input_text_single, emo_upload, emo_weight,
-                            vec1, vec2, vec3, vec4, vec5, vec6, vec7, vec8,
-                             emo_text,emo_random,
-                             max_text_tokens_per_segment,
-                             *advanced_params,
-                     ],
-                     outputs=[output_audio])
+    generation_inputs = [
+        input_text_single,
+        emo_random,
+        max_text_tokens_per_segment,
+        do_sample,
+        top_p,
+        top_k,
+        temperature,
+        length_penalty,
+        num_beams,
+        repetition_penalty,
+        max_mel_tokens,
+    ]
+    for row in speaker_rows:
+        generation_inputs.extend([row["active"], row["audio"], row["weight"]])
+    for row in emotion_rows:
+        generation_inputs.extend(
+            [row["active"], row["type"], row["speaker_index"], row["audio"], row["text"], row["weight"], *row["vector"]]
+        )
 
+    gen_button.click(
+        prepare_generation,
+        inputs=[],
+        outputs=[output_audio, generation_status],
+    ).then(
+        gen_single,
+        inputs=generation_inputs,
+        outputs=[output_audio, generation_status],
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 ## Summary

  This PR updates the multi-reference WebUI flow so that speaker-linked emotion rows are explicit and unambiguous when multiple speaker references are active.

  ### What changed

  - require users to choose the matching speaker reference when an emotion row uses the "same as speaker reference" mode
  - add structured normalization and selection helpers for speaker-linked emotion references
  - add reusable reference-conditioning utilities for weighted multi-reference fusion and feature caching
  - update inference to support structured speaker/emotion reference inputs and reuse precomputed conditioning latents
  - refactor WebUI reference collection logic into dedicated helpers and refresh speaker-target selectors dynamically
  - document multi-reference Python usage in both English and Chinese READMEs

  ### Why

  Previously, once multiple speaker references were active, a speaker-linked emotion row did not explicitly declare which speaker reference it should follow. That made the behavior ambiguous. This change makes
  the mapping explicit in the UI and enforces it in the backend.

  ## Testing

  - `.\.venv\Scripts\python.exe -m py_compile webui.py indextts\infer_v2.py indextts\gpt\model_v2.py indextts\emotion_reference_selection.py indextts\reference_conditioning.py
  indextts\webui_reference_inputs.py`
  - `.\.venv\Scripts\python.exe -m pytest tests\test_multi_reference_conditioning.py tests\test_emotion_reference_speaker_selection.py -q`

  ## Notes

  - `/logs/` is now ignored
  - README updates are included to document the multi-reference API additions