### PR TITLE
Fix WebUI Hugging Face cache path initialization

### DIFF
--- a/indextts/infer_v2.py
+++ b/indextts/infer_v2.py
@@ -1,7 +1,7 @@
 import os
 from subprocess import CalledProcessError
 
-os.environ['HF_HUB_CACHE'] = './checkpoints/hf_cache'
+os.environ.setdefault('HF_HUB_CACHE', './checkpoints/hf_cache')
 import json
 import re
 import time

--- a/webui.py
+++ b/webui.py
@@ -47,6 +47,9 @@ for file in [
         print(f"Required file {file_path} does not exist. Please download it.")
         sys.exit(1)
 
+hf_cache_dir = os.path.abspath(os.path.join(cmd_args.model_dir, "hf_cache"))
+os.environ.setdefault("HF_HUB_CACHE", hf_cache_dir)
+
 import gradio as gr
 from indextts.infer_v2 import IndexTTS2
 from tools.i18n.i18n import I18nAuto


### PR DESCRIPTION
This PR fixes a WebUI cache path issue where Hugging Face Hub may initialize its default cache directory before `indextts.infer_v2` sets `HF_HUB_CACHE`.

`webui.py` imports `gradio` before importing `IndexTTS2`, and `gradio` imports `huggingface_hub`. Once `huggingface_hub` is imported, its cache constant may already point to the user default cache directory, such as `C:\Users\<user>\.cache\huggingface\hub`.

This change sets `HF_HUB_CACHE` to `<model_dir>/hf_cache` before importing `gradio`, keeping WebUI model cache files under the configured model directory.

Fixes #690
Related to #616 and #658 .