### PR TITLE
Constrain Python version for llvmlite compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
   "Operating System :: OS Independent",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.12"
 dependencies = [
   # IMPORTANT: Always run `uv lock` or `uv lock --upgrade` to resolve dependencies
   # and update the lockfile after editing anything below.

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.12"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",


### PR DESCRIPTION
## Summary

This PR constrains the supported Python range to `>=3.10,<3.12`.

The project currently pins `numba==0.58.1`, which depends on `llvmlite==0.41.1`. On Windows, `llvmlite==0.41.1` provides wheels for Python 3.10 and 3.11, but not Python 3.12. When `uv tool install .` selects Python 3.12, installation falls back to building `llvmlite` from source and fails.

This PR only addresses the Python version compatibility issue.

## Changes

- Update `pyproject.toml` from `requires-python = ">=3.10"` to `requires-python = ">=3.10,<3.12"`.
- Update `uv.lock` to match the same Python version constraint.