### PR TITLE
Fix forwarding of the do_sample option in IndexTTS2

### DIFF
--- a/indextts/infer_v2.py
+++ b/indextts/infer_v2.py
@@ -576,7 +576,7 @@ class IndexTTS2:
                         cond_lengths=torch.tensor([spk_cond_emb.shape[-1]], device=text_tokens.device),
                         emo_cond_lengths=torch.tensor([emo_cond_emb.shape[-1]], device=text_tokens.device),
                         emo_vec=emovec,
-                        do_sample=True,
+                        do_sample=do_sample,
                         top_p=top_p,
                         top_k=top_k,
                         temperature=temperature,


### PR DESCRIPTION
## Description

`infer_generator()` already reads `do_sample` from `generation_kwargs`,
defaulting to `True`, but the parsed value is ignored because
`inference_speech()` is called with a hard-coded `do_sample=True`.

This change forwards the parsed value.

The default behavior remains unchanged. Only an explicitly supplied
`do_sample=False` is now respected.

Fixes #577

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How has this been tested?

The change was reviewed against the existing argument flow. The default
remains `True`, and the patch only replaces the hard-coded value with the
already parsed local variable.

## Checklist

- [ ] Tests pass locally: `uv run pytest -m "not gpu"` (no GPU) or
  `uv run pytest tests/test_v2.py` (with GPU)
- [ ] I have added or updated tests to cover my changes (where applicable).
- [ ] I have added or updated docstrings for any changed public functions.

> **AI assistance disclosure:** AI assistance was used to organize and edit
> this pull request description. I reviewed the change and all technical claims.