### PR TITLE
Fix severe clipping when saving generated audio

### DIFF
--- a/indextts/infer_v2.py
+++ b/indextts/infer_v2.py
@@ -702,7 +702,16 @@ class IndexTTS2:
                 print(">> remove old wav file:", output_path)
             if os.path.dirname(output_path) != "":
                 os.makedirs(os.path.dirname(output_path), exist_ok=True)
-            torchaudio.save(output_path, wav.type(torch.int16), sampling_rate)
+            # torchaudio.save() with an int16 tensor treats the values as if
+            # they were already normalised to [-1, 1] and scales by 32768 a
+            # second time, so every sample past ~1/32768 of full scale clips.
+            # `wav` is in [-32767, 32767] here (see the clamp above), so it is
+            # normalised back before saving.
+            wav_normalized = wav.float() / 32768.0
+            # torchaudio wants (channels, samples).
+            if wav_normalized.dim() == 1:
+                wav_normalized = wav_normalized.unsqueeze(0)
+            torchaudio.save(output_path, wav_normalized, sampling_rate)
             print(">> wav file saved to:", output_path)
             if stream_return:
                 return None


### PR DESCRIPTION
### The bug

`infer_v2.py` scales the waveform into int16 range and then hands the int16 tensor to `torchaudio.save()`:

```python
wav = torch.clamp(32767 * wav, -32767.0, 32767.0)
...
torchaudio.save(output_path, wav.type(torch.int16), sampling_rate)
```

`torchaudio.save()` treats an int16 tensor as if it were already normalised to `[-1, 1]` and scales by 32768 again, so everything past roughly 1/32768 of full scale rails. Every clip written to a file is affected — the in-memory Gradio path (`yield (sampling_rate, wav_data)`) is fine, which is why this is easy to miss.

### Measurement

A half-scale 440 Hz sine, saved both ways on torchaudio 2.11:

| | peak | samples at full scale |
|---|---|---|
| `wav.type(torch.int16)` | 1.0000 | 22043 / 22050 |
| normalised to `[-1, 1]` first | 0.5000 | 0 |

The first is a square wave.

### The fix

Normalise back to `[-1, 1]` before saving, and add the channel dimension `torchaudio` expects. Verified on an RTX PRO 6000 with CUDA 13: a real synthesis returns peak 0.511 with the patch and would rail to 1.000 without it.

We hit this running IndexTTS 2 in a dubbing pipeline, where it affected every generated segment.