### PR TITLE
fix: use IndexTTS2 for v2 model configs in CLI

### DIFF
--- a/indextts/cli.py
+++ b/indextts/cli.py
@@ -91,9 +91,9 @@ def _cmd_infer(args):
             args.fp16 = False
             print("WARNING: Running on CPU may be slow.")
 
-    from indextts.infer import IndexTTS
-    tts = IndexTTS(cfg_path=args.config, model_dir=args.model_dir, use_fp16=args.fp16, device=args.device)
-    tts.infer(audio_prompt=args.voice, text=args.text.strip(), output_path=output_path)
+    from indextts.infer_v2 import IndexTTS2
+    tts = IndexTTS2(cfg_path=args.config, model_dir=args.model_dir, use_fp16=args.fp16, device=args.device)
+    tts.infer(spk_audio_prompt=args.voice, text=args.text.strip(), output_path=output_path)
 
 
 def main():


### PR DESCRIPTION
## Summary
`indextts/cli.py` hardcodes the v1 `IndexTTS` inferencer, but the default checkpoints (config.yaml `version: 2.0`) are v2. Running `indextts infer` against v2 models fails with:
```
TypeError: UnifiedVoice.__init__() got an unexpected keyword argument 'emo_condition_module'
```

This PR routes the CLI to `IndexTTS2` (v2 inferencer) with the correct `spk_audio_prompt` parameter name.

## Test Plan
- `indextts infer` with v2 checkpoints + 5s reference audio: 6.7s total inference, output wav generated
- Repo tests: 7 passed (v2 model load verified)