### PR TITLE
webui: default to IndexTTS-2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ uv run tools/gpu_check.py
 
 ```bash
 # IndexTTS-2.5 (default)
-uv run webui.py --version 2.5 --model_dir ./checkpoints
+uv run webui.py
 
 # IndexTTS-2
 uv run webui.py --version 2 --model_dir ./checkpoints_2

--- a/docs/README_ar.md
+++ b/docs/README_ar.md
@@ -167,7 +167,7 @@ uv run tools/gpu_check.py
 
 ```bash
 # IndexTTS-2.5 (default)
-uv run webui.py --version 2.5 --model_dir ./checkpoints
+uv run webui.py
 
 # IndexTTS-2
 uv run webui.py --version 2 --model_dir ./checkpoints_2

--- a/docs/README_es.md
+++ b/docs/README_es.md
@@ -175,7 +175,7 @@ uv run tools/gpu_check.py
 
 ```bash
 # IndexTTS-2.5 (default)
-uv run webui.py --version 2.5 --model_dir ./checkpoints
+uv run webui.py
 
 # IndexTTS-2
 uv run webui.py --version 2 --model_dir ./checkpoints_2

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -169,7 +169,7 @@ uv run tools/gpu_check.py
 
 ```bash
 # IndexTTS-2.5 (default)
-uv run webui.py --version 2.5 --model_dir ./checkpoints
+uv run webui.py
 
 # IndexTTS-2
 uv run webui.py --version 2 --model_dir ./checkpoints_2

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -160,7 +160,7 @@ uv run tools/gpu_check.py
 
 ```bash
 # IndexTTS-2.5（默认）
-uv run webui.py --version 2.5 --model_dir ./checkpoints
+uv run webui.py
 
 # IndexTTS-2
 uv run webui.py --version 2 --model_dir ./checkpoints_2

--- a/indextts/utils/model_download.py
+++ b/indextts/utils/model_download.py
@@ -80,14 +80,15 @@ def _download_single_file(repo_id: str, filename: str, local_path: str) -> str:
     return local_path
 
 
-def ensure_config_available(model_dir: str) -> None:
+def ensure_config_available(model_dir: str, version: str = "2") -> None:
     """Download only ``config.yaml`` if it is missing from *model_dir*."""
     model_dir = model_dir or "."
     config_path = os.path.join(model_dir, "config.yaml")
     if os.path.isfile(config_path):
         return
     print(f">> config.yaml not found in {model_dir}, downloading...")
-    _download_single_file("IndexTeam/IndexTTS-2", "config.yaml", config_path)
+    repo_id = "IndexTeam/IndexTTS-2.5" if version == "2.5" else "IndexTeam/IndexTTS-2"
+    _download_single_file(repo_id, "config.yaml", config_path)
     print(">> config.yaml downloaded.")
 
 

--- a/indextts/utils/model_download.py
+++ b/indextts/utils/model_download.py
@@ -80,14 +80,25 @@ def _download_single_file(repo_id: str, filename: str, local_path: str) -> str:
     return local_path
 
 
-def ensure_config_available(model_dir: str, version: str = "2") -> None:
+_VERSION_TO_REPO = {
+    "2": "IndexTeam/IndexTTS-2",
+    "2.5": "IndexTeam/IndexTTS-2.5",
+}
+
+
+def ensure_config_available(model_dir: str, version: str = "2.5") -> None:
     """Download only ``config.yaml`` if it is missing from *model_dir*."""
+    if version not in _VERSION_TO_REPO:
+        supported = ", ".join(sorted(_VERSION_TO_REPO))
+        raise ValueError(
+            f"Unsupported model version {version!r}. Supported versions: {supported}"
+        )
     model_dir = model_dir or "."
     config_path = os.path.join(model_dir, "config.yaml")
     if os.path.isfile(config_path):
         return
     print(f">> config.yaml not found in {model_dir}, downloading...")
-    repo_id = "IndexTeam/IndexTTS-2.5" if version == "2.5" else "IndexTeam/IndexTTS-2"
+    repo_id = _VERSION_TO_REPO[version]
     _download_single_file(repo_id, "config.yaml", config_path)
     print(">> config.yaml downloaded.")
 

--- a/webui.py
+++ b/webui.py
@@ -25,7 +25,7 @@ parser.add_argument("--verbose", action="store_true", default=False, help="Enabl
 parser.add_argument("--port", type=int, default=7860, help="Port to run the web UI on")
 parser.add_argument("--host", type=str, default="0.0.0.0", help="Host to run the web UI on")
 parser.add_argument("--model_dir", type=str, default="./checkpoints", help="Model checkpoints directory")
-parser.add_argument("--version", type=str, default="2", choices=["2", "2.5"], help="Model version to use")
+parser.add_argument("--version", type=str, default="2.5", choices=["2", "2.5"], help="Model version to use")
 parser.add_argument("--fp16", action="store_true", default=False, help="Use FP16 for inference if available")
 parser.add_argument("--deepspeed", action="store_true", default=False, help="Use DeepSpeed to accelerate if available")
 parser.add_argument("--cuda_kernel", action="store_true", default=False, help="Use CUDA kernel for inference if available")
@@ -51,27 +51,30 @@ if cmd_args.accel:
 if cmd_args.torch_compile:
     _require_optional_extra("torch_compile", "triton", "uv sync --extra torch_compile")
 
-required_files = [
-    "bpe.model",
-    "gpt.pth",
-    "s2mel.pth",
-    "wav2vec2bert_stats.pt",
-]
+REQUIRED_FILES = {
+    "2": ["bpe.model", "gpt.pth", "s2mel.pth", "wav2vec2bert_stats.pt"],
+    "2.5": [
+        "gpt.pth",
+        "s2mel.pth",
+        "codec.pth",
+        "multilingual_zh_ja_yue_char_del.tiktoken",
+        "wav2vec2bert_stats.pt",
+    ],
+}
+MODEL_REPO = {
+    "2": "IndexTeam/IndexTTS-2",
+    "2.5": "IndexTeam/IndexTTS-2.5",
+}
+required_files = REQUIRED_FILES[cmd_args.version]
 missing = [f for f in required_files if not os.path.exists(os.path.join(cmd_args.model_dir, f))]
 if missing:
-    if cmd_args.version != "2":
-        print(
-            f"Model directory {cmd_args.model_dir} is incomplete for v{cmd_args.version} "
-            f"(missing: {', '.join(missing)}). Please prepare checkpoints manually."
-        )
-        sys.exit(1)
     print(
-        f"Model directory {cmd_args.model_dir} is incomplete (missing: {', '.join(missing)}). "
-        "Downloading IndexTTS-2 model..."
+        f"Model directory {cmd_args.model_dir} is incomplete for v{cmd_args.version} "
+        f"(missing: {', '.join(missing)}). Downloading {MODEL_REPO[cmd_args.version]}..."
     )
     from indextts.utils.model_download import snapshot_download
     try:
-        snapshot_download("IndexTeam/IndexTTS-2", local_dir=cmd_args.model_dir)
+        snapshot_download(MODEL_REPO[cmd_args.version], local_dir=cmd_args.model_dir)
     except Exception as e:
         print(f"Failed to download model to {cmd_args.model_dir}: {e}")
         sys.exit(1)
@@ -83,7 +86,7 @@ if missing:
 
 from indextts.utils.model_download import ensure_config_available
 try:
-    ensure_config_available(cmd_args.model_dir)
+    ensure_config_available(cmd_args.model_dir, version=cmd_args.version)
 except Exception as e:
     print(f"Failed to download config.yaml: {e}")
     sys.exit(1)


### PR DESCRIPTION
## What

`uv run webui.py` now launches **IndexTTS-2.5** by default (was `2`).

## Why

The `--version` default was pinned to `2` only because the empty-checkpoints auto-download fallback was implemented for v2 alone — 2.5 just exited with "please prepare manually". So a fresh user running `uv run webui.py` with no flags self-bootstrapped v2, not 2.5 (the flagship). This wires up the 2.5 bootstrap path so the zero-arg default matches the release.

## Changes

- `webui.py`: `--version` default `2` → `2.5`.
- `webui.py`: version-aware `required_files` + `MODEL_REPO`. Both versions auto-download their own repo (`IndexTeam/IndexTTS-2` / `IndexTeam/IndexTTS-2.5`) when `./checkpoints` is incomplete. The v2-only auto-download special-case is gone.
  - v2 required: `bpe.model`, `gpt.pth`, `s2mel.pth`, `wav2vec2bert_stats.pt`
  - 2.5 required: `gpt.pth`, `s2mel.pth`, `codec.pth`, `multilingual_zh_ja_yue_char_del.tiktoken`, `wav2vec2bert_stats.pt` (`bpe.model` is v2-only; 2.5 uses tiktoken)
- `model_download.py`: `ensure_config_available(model_dir, version)` downloads `config.yaml` from the matching repo instead of hardcoded `IndexTeam/IndexTTS-2`.
- README (en + zh): 2.5 launch is now `uv run webui.py` (zero flags); v2 keeps `--version 2 --model_dir ./checkpoints_2`.

## Verification

- Non-GPU test suite: 10/10 pass (`test_model_download_reachable` is network-flaky, passes in isolation).
- Syntax + content assertions on `webui.py` / `model_download.py` pass.

## Compatibility

Backward compatible: explicit `--version 2` still works identically. Existing `./checkpoints` (2.5) now launches 2.5 directly without needing `--version 2.5`.