### PR TITLE
fix: repair Linux installs and README commands that fail on a clean machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ this repository:
 git clone https://github.com/index-tts/index-tts.git && cd index-tts
 ```
 
-Example audio files are downloaded on demand from HuggingFace/ModelScope on
-first run, so Git LFS is no longer required.
+Example audio files are downloaded on demand from HuggingFace/ModelScope the
+first time the WebUI starts, so Git LFS is no longer required.
 
 ### 2. Install Dependencies
 
@@ -123,7 +123,7 @@ Download the required models via [uv tool](https://docs.astral.sh/uv/guides/tool
 Via `huggingface-cli`:
 
 ```bash
-uv tool install "huggingface-hub[cli,hf_xet]"
+uv tool install "huggingface-hub[hf_xet]"
 
 # IndexTTS-2.5
 hf download IndexTeam/IndexTTS-2.5 --local-dir=checkpoints
@@ -208,9 +208,6 @@ To run scripts, use `uv run <file.py>` so the code runs inside the `uv`
 environment. You may also need to add the current directory to `PYTHONPATH`:
 
 ```bash
-# IndexTTS2
-PYTHONPATH="$PYTHONPATH:." uv run indextts/infer_v2.py
-
 # IndexTTS2.5
 PYTHONPATH="$PYTHONPATH:." uv run indextts/infer_v2_5.py \
   --cfg_path checkpoints/config.yaml \
@@ -218,6 +215,17 @@ PYTHONPATH="$PYTHONPATH:." uv run indextts/infer_v2_5.py \
   --text "Hello world" \
   --lang EN
 ```
+
+The default `--prompt_wav` lives in `examples/`, which is populated the first
+time the WebUI starts. To fetch it without the WebUI:
+
+```bash
+uv run python -c "from indextts.utils.examples_downloader import ensure_examples_available; ensure_examples_available()"
+```
+
+For IndexTTS2, use the Python API below — `indextts/infer_v2.py` runs a
+benchmark loop against a hardcoded `checkpoints/` directory, not the
+`checkpoints_2` layout from step 3.
 
 #### 0. Initialize IndexTTS
 
@@ -284,10 +292,10 @@ Use `use_random` to introduce stochasticity during inference (default: `False`).
 text = "对不起嘛！我的记性真的不太好，但是和你在一起的事情，我都会努力记住的~"
 
 # IndexTTS2
-tts.infer(spk_audio_prompt='examples/09.wav', text=text, output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
+tts.infer(spk_audio_prompt='examples/voice_09.wav', text=text, output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
 
 # IndexTTS2.5
-tts.infer(spk_audio_prompt='examples/09.wav', text=text, lang="ZH", output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
+tts.infer(spk_audio_prompt='examples/voice_09.wav', text=text, lang="ZH", output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
 ```
 
 #### 5. Emotion control from the text itself (`use_emo_text`)
@@ -295,6 +303,11 @@ tts.infer(spk_audio_prompt='examples/09.wav', text=text, lang="ZH", output_path=
 Enable `use_emo_text` to automatically convert your `text` script into emotion
 vectors. An `emo_alpha` around 0.6 (or lower) is recommended for more natural
 speech. Randomness can be introduced with `use_random` (default: `False`).
+
+> [!IMPORTANT]
+> This and the next example need the QwenEmotion model, which is only loaded
+> when you construct IndexTTS2.5 with `use_qwen_emo=True`. Without it,
+> `use_emo_text=True` raises a `RuntimeError`.
 
 ```python
 text = "快躲起来！是他要来了！他要来抓我们了！"

--- a/README.md
+++ b/README.md
@@ -305,9 +305,8 @@ vectors. An `emo_alpha` around 0.6 (or lower) is recommended for more natural
 speech. Randomness can be introduced with `use_random` (default: `False`).
 
 > [!IMPORTANT]
-> This and the next example need the QwenEmotion model, which is only loaded
-> when you construct IndexTTS2.5 with `use_qwen_emo=True`. Without it,
-> `use_emo_text=True` raises a `RuntimeError`.
+> For IndexTTS-2.5, `use_emo_text=True` requires constructing `IndexTTS2` with `use_qwen_emo=True` (e.g. `tts = IndexTTS2(..., use_qwen_emo=True)`), otherwise it raises a `RuntimeError`.
+> (IndexTTS-2 does not require this flag.)
 
 ```python
 text = "快躲起来！是他要来了！他要来抓我们了！"

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Download the required models via [uv tool](https://docs.astral.sh/uv/guides/tool
 Via `huggingface-cli`:
 
 ```bash
-uv tool install "huggingface-hub[hf_xet]"
+uv tool install "huggingface-hub"
 
 # IndexTTS-2.5
 hf download IndexTeam/IndexTTS-2.5 --local-dir=checkpoints

--- a/archive/README_INDEXTTS_2.md
+++ b/archive/README_INDEXTTS_2.md
@@ -388,7 +388,7 @@ tts.infer(spk_audio_prompt='examples/voice_07.wav', text=text, output_path="gen.
 from indextts.infer_v2 import IndexTTS2
 tts = IndexTTS2(cfg_path="checkpoints/config.yaml", model_dir="checkpoints", use_fp16=False, use_cuda_kernel=False, use_deepspeed=False)
 text = "对不起嘛！我的记性真的不太好，但是和你在一起的事情，我都会努力记住的~"
-tts.infer(spk_audio_prompt='examples/09.wav', text=text, output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
+tts.infer(spk_audio_prompt='examples/voice_09.wav', text=text, output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
 ```
 
 5. Alternatively, you can enable `use_emo_text` to guide the emotions based on

--- a/archive/README_INDEXTTS_2.md
+++ b/archive/README_INDEXTTS_2.md
@@ -234,7 +234,7 @@ uv sync --all-extras --default-index "https://mirrors.tuna.tsinghua.edu.cn/pypi/
 Download via `huggingface-cli`:
 
 ```bash
-uv tool install "huggingface-hub[cli,hf_xet]"
+uv tool install "huggingface-hub"
 
 hf download IndexTeam/IndexTTS-2 --local-dir=checkpoints
 hf download IndexTeam/IndexTTS-2.5 --local-dir=checkpoints

--- a/archive/README_INDEXTTS_2_ZH.md
+++ b/archive/README_INDEXTTS_2_ZH.md
@@ -185,7 +185,7 @@ uv sync --all-extras --default-index "https://mirrors.tuna.tsinghua.edu.cn/pypi/
 HuggingFace下载：
 
 ```bash
-uv tool install "huggingface-hub[cli,hf_xet]"
+uv tool install "huggingface-hub"
 
 hf download IndexTeam/IndexTTS-2 --local-dir=checkpoints
 ```

--- a/docs/README2.5_ZH.md
+++ b/docs/README2.5_ZH.md
@@ -320,10 +320,10 @@ tts.infer(spk_audio_prompt='examples/voice_07.wav', text=text, output_path="gen.
 text = "对不起嘛！我的记性真的不太好，但是和你在一起的事情，我都会努力记住的~"
 
 # IndexTTS2
-tts.infer(spk_audio_prompt='examples/09.wav', text=text, output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
+tts.infer(spk_audio_prompt='examples/voice_09.wav', text=text, output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
 
 # IndexTTS2.5
-tts.infer(spk_audio_prompt='examples/09.wav', text=text, lang="ZH", output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
+tts.infer(spk_audio_prompt='examples/voice_09.wav', text=text, lang="ZH", output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
 ```
 
 5. 可开启 `use_emo_text` 根据输入文本自动生成情感向量。

--- a/docs/README2.5_ZH.md
+++ b/docs/README2.5_ZH.md
@@ -172,7 +172,7 @@ uv sync --all-extras --default-index "https://mirrors.tuna.tsinghua.edu.cn/pypi/
 HuggingFace下载：
 
 ```bash
-uv tool install "huggingface-hub[cli,hf_xet]"
+uv tool install "huggingface-hub"
 
 hf download IndexTeam/IndexTTS-2 --local-dir=checkpoints
 hf download IndexTeam/IndexTTS-2.5 --local-dir=checkpoints

--- a/docs/README_ar.md
+++ b/docs/README_ar.md
@@ -280,10 +280,10 @@ tts.infer(spk_audio_prompt='examples/voice_07.wav', text=text, output_path="gen.
 text = "对不起嘛！我的记性真的不太好，但是和你在一起的事情，我都会努力记住的~"
 
 # IndexTTS2
-tts.infer(spk_audio_prompt='examples/09.wav', text=text, output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
+tts.infer(spk_audio_prompt='examples/voice_09.wav', text=text, output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
 
 # IndexTTS2.5
-tts.infer(spk_audio_prompt='examples/09.wav', text=text, lang="ZH", output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
+tts.infer(spk_audio_prompt='examples/voice_09.wav', text=text, lang="ZH", output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
 ```
 
 #### 5. التحكم في المشاعر من النص نفسه (`use_emo_text`)

--- a/docs/README_ar.md
+++ b/docs/README_ar.md
@@ -120,7 +120,7 @@ uv sync --all-extras --default-index "https://mirrors.tuna.tsinghua.edu.cn/pypi/
 عبر `huggingface-cli`:
 
 ```bash
-uv tool install "huggingface-hub[cli,hf_xet]"
+uv tool install "huggingface-hub"
 
 # IndexTTS-2.5
 hf download IndexTeam/IndexTTS-2.5 --local-dir=checkpoints

--- a/docs/README_es.md
+++ b/docs/README_es.md
@@ -126,7 +126,7 @@ Descarga los modelos necesarios mediante [uv tool](https://docs.astral.sh/uv/gui
 Mediante `huggingface-cli`:
 
 ```bash
-uv tool install "huggingface-hub[cli,hf_xet]"
+uv tool install "huggingface-hub"
 
 # IndexTTS-2.5
 hf download IndexTeam/IndexTTS-2.5 --local-dir=checkpoints

--- a/docs/README_es.md
+++ b/docs/README_es.md
@@ -294,10 +294,10 @@ Usa `use_random` para introducir estocasticidad durante la inferencia
 text = "对不起嘛！我的记性真的不太好，但是和你在一起的事情，我都会努力记住的~"
 
 # IndexTTS2
-tts.infer(spk_audio_prompt='examples/09.wav', text=text, output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
+tts.infer(spk_audio_prompt='examples/voice_09.wav', text=text, output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
 
 # IndexTTS2.5
-tts.infer(spk_audio_prompt='examples/09.wav', text=text, lang="ZH", output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
+tts.infer(spk_audio_prompt='examples/voice_09.wav', text=text, lang="ZH", output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
 ```
 
 #### 5. Control de emociones a partir del propio texto (`use_emo_text`)

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -121,7 +121,7 @@ uv sync --all-extras --default-index "https://mirrors.tuna.tsinghua.edu.cn/pypi/
 `huggingface-cli` を使う場合：
 
 ```bash
-uv tool install "huggingface-hub[cli,hf_xet]"
+uv tool install "huggingface-hub"
 
 # IndexTTS-2.5
 hf download IndexTeam/IndexTTS-2.5 --local-dir=checkpoints

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -284,10 +284,10 @@ tts.infer(spk_audio_prompt='examples/voice_07.wav', text=text, output_path="gen.
 text = "对不起嘛！我的记性真的不太好，但是和你在一起的事情，我都会努力记住的~"
 
 # IndexTTS2
-tts.infer(spk_audio_prompt='examples/09.wav', text=text, output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
+tts.infer(spk_audio_prompt='examples/voice_09.wav', text=text, output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
 
 # IndexTTS2.5
-tts.infer(spk_audio_prompt='examples/09.wav', text=text, lang="ZH", output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
+tts.infer(spk_audio_prompt='examples/voice_09.wav', text=text, lang="ZH", output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
 ```
 
 #### 5. テキスト自体からの感情コントロール（`use_emo_text`）

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -269,10 +269,10 @@ tts.infer(spk_audio_prompt='examples/voice_07.wav', text=text, output_path="gen.
 text = "对不起嘛！我的记性真的不太好，但是和你在一起的事情，我都会努力记住的~"
 
 # IndexTTS2
-tts.infer(spk_audio_prompt='examples/09.wav', text=text, output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
+tts.infer(spk_audio_prompt='examples/voice_09.wav', text=text, output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
 
 # IndexTTS2.5
-tts.infer(spk_audio_prompt='examples/09.wav', text=text, lang="ZH", output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
+tts.infer(spk_audio_prompt='examples/voice_09.wav', text=text, lang="ZH", output_path="gen.wav", emo_vector=[0, 0, 0.8, 0, 0, 0, 0, 0], use_random=False, verbose=True)
 ```
 
 #### 5. 根据文本自动生成情感（`use_emo_text`）

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -115,7 +115,7 @@ uv sync --all-extras --default-index "https://mirrors.tuna.tsinghua.edu.cn/pypi/
 HuggingFace 下载：
 
 ```bash
-uv tool install "huggingface-hub[cli,hf_xet]"
+uv tool install "huggingface-hub"
 
 # IndexTTS-2.5
 hf download IndexTeam/IndexTTS-2.5 --local-dir=checkpoints

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,12 +82,12 @@ accel = [
   "flash-attn==2.8.3.post1",
   "nvidia-cuda-runtime-cu12",
   "nvidia-cudnn-cu12",
-  "triton-windows==3.1.0.post17",
+  "triton-windows==3.1.0.post17; sys_platform == 'win32'",
 ]
 # To install torch.compile support for s2mel, use `uv sync --extra torch_compile` (or `--all-extras`).
 # On Windows this is satisfied by the triton-windows package above.
 torch_compile = [
-  "triton-windows==3.1.0.post17",
+  "triton-windows==3.1.0.post17; sys_platform == 'win32'",
 ]
 test = [
   "pytest>=7.0",
@@ -113,13 +113,12 @@ indextts2 = "indextts.cli_v2:main"
 requires = ["hatchling >= 1.27.0"]
 build-backend = "hatchling.build"
 
-[tool.uv]
-# Disable build isolation when building DeepSpeed from source.
-# NOTE: This is *necessary* so that DeepSpeed builds directly within our `.venv`,
-# and finds our CUDA-enabled version of PyTorch, which DeepSpeed *needs* during
-# its compilation to determine what GPU support to compile for itself. It also
-# saves time, since it won't waste time downloading a generic PyTorch version.
-no-build-isolation-package = ["deepspeed"]
+[tool.uv.extra-build-dependencies]
+# Build against our CUDA-enabled PyTorch: DeepSpeed picks its GPU targets from it,
+# and flash-attn reads its version and C++ ABI flag to fetch a matching prebuilt
+# wheel instead of compiling.
+deepspeed = [{ requirement = "torch", match-runtime = true }]
+flash-attn = [{ requirement = "torch", match-runtime = true }]
 
 [tool.uv.sources]
 # Install PyTorch with CUDA support on Linux/Windows (CUDA doesn't exist for Mac).

--- a/uv.lock
+++ b/uv.lock
@@ -882,7 +882,7 @@ accel = [
     { name = "flash-attn" },
     { name = "nvidia-cuda-runtime-cu12" },
     { name = "nvidia-cudnn-cu12" },
-    { name = "triton-windows" },
+    { name = "triton-windows", marker = "sys_platform == 'win32'" },
 ]
 deepspeed = [
     { name = "deepspeed" },
@@ -891,7 +891,7 @@ test = [
     { name = "pytest" },
 ]
 torch-compile = [
-    { name = "triton-windows" },
+    { name = "triton-windows", marker = "sys_platform == 'win32'" },
 ]
 webui = [
     { name = "gradio" },
@@ -939,8 +939,8 @@ requires-dist = [
     { name = "torchaudio", marker = "sys_platform == 'linux' or sys_platform == 'win32'", specifier = "==2.8.*", index = "https://download.pytorch.org/whl/cu128" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "transformers", specifier = "==4.52.1" },
-    { name = "triton-windows", marker = "extra == 'accel'", specifier = "==3.1.0.post17" },
-    { name = "triton-windows", marker = "extra == 'torch-compile'", specifier = "==3.1.0.post17" },
+    { name = "triton-windows", marker = "sys_platform == 'win32' and extra == 'accel'", specifier = "==3.1.0.post17" },
+    { name = "triton-windows", marker = "sys_platform == 'win32' and extra == 'torch-compile'", specifier = "==3.1.0.post17" },
     { name = "unidic-lite", specifier = ">=1.0.0" },
     { name = "wetext", marker = "sys_platform != 'linux'", specifier = ">=0.0.9" },
     { name = "wetextprocessing", marker = "sys_platform == 'linux'" },
@@ -2872,7 +2872,7 @@ name = "triton-windows"
 version = "3.1.0.post17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
+    { name = "filelock", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/02/0834e8ae1611bbed61ce9ddff0ab3621f7ccaf4578f17e8a0eada7248e21/triton_windows-3.1.0.post17-cp310-cp310-win_amd64.whl", hash = "sha256:7b7fa746a2abf12e28a3c61288e636d211169abb575a1241aa7f94b8b26579ca", size = 31778065, upload-time = "2025-03-25T04:49:42.574Z" },

--- a/webui.py
+++ b/webui.py
@@ -660,7 +660,7 @@ def create_experimental_warning_message():
     return create_warning_message(i18n('提示：此功能为实验版，结果尚不稳定，我们正在持续优化中。'))
 
 with gr.Blocks(
-    title="IndexTTS Demo",
+    title=f"IndexTTS-{cmd_args.version} Demo",
     css="""
         /* Make the voice reference audio upload area more compact. */
         #prompt_audio_compact .audio-container,
@@ -708,10 +708,11 @@ with gr.Blocks(
     """,
 ) as demo:
     mutex = threading.Lock()
-    gr.HTML('''
-    <h2><center>IndexTTS2: A Breakthrough in Emotionally Expressive and Duration-Controlled Auto-Regressive Zero-Shot Text-to-Speech</h2>
+    arxiv_id = "2601.03888" if IS_V25 else "2506.21619"
+    gr.HTML(f'''
+    <h2><center>IndexTTS-{cmd_args.version}</h2>
 <p align="center">
-<a href='https://arxiv.org/abs/2506.21619'><img src='https://img.shields.io/badge/ArXiv-2506.21619-red'></a>
+<a href='https://arxiv.org/abs/{arxiv_id}'><img src='https://img.shields.io/badge/ArXiv-{arxiv_id}-red'></a>
 </p>
     ''')
 

--- a/webui.py
+++ b/webui.py
@@ -709,8 +709,8 @@ with gr.Blocks(
 ) as demo:
     mutex = threading.Lock()
     arxiv_id = "2601.03888" if IS_V25 else "2506.21619"
-    gr.HTML(f'''
-    <h2><center>IndexTTS-{cmd_args.version}</h2>
+gr.HTML(f'''
+    <h2 style="text-align:center">IndexTTS-{cmd_args.version}</h2>
 <p align="center">
 <a href='https://arxiv.org/abs/{arxiv_id}'><img src='https://img.shields.io/badge/ArXiv-{arxiv_id}-red'></a>
 </p>


### PR DESCRIPTION
Everything here was found by running the README start-to-finish on a Linux GPU box in a **fresh clone with a fresh `.venv` and a separate `UV_CACHE_DIR`**. A warm cache or an existing venv hides every one of these, which is why they survived this long.

## Installation (`pyproject.toml`)

**`uv sync --all-extras` could not succeed on Linux.** Two independent blockers:

1. `triton-windows` carried no platform marker, so uv treated it as required everywhere:

   ```
   error: Distribution `triton-windows==3.1.0.post17` can't be installed because it
   doesn't have a source distribution or wheel for the current platform
   hint: You're on Linux (`manylinux_2_28_x86_64`), but `triton-windows` only has
   wheels for the following platform: `win_amd64`
   ```

   Linux already receives `triton` as a torch dependency, so the package is Windows-only by design — the marker was just missing.

2. `no-build-isolation-package = ["deepspeed"]` made deepspeed fail on any clean machine:

   ```
   × Failed to build `deepspeed==0.17.1`
   ╰─▶ ModuleNotFoundError: No module named 'setuptools'
   ```

   That mode uses `.venv` itself as the build environment, and a fresh `.venv` has no setuptools at build time. (Adding setuptools to `dependencies` does not help — uv builds all sdists before installing anything.)

   Switching to `extra-build-dependencies` with `match-runtime = true` keeps the CUDA-enabled torch the build needs while leaving isolation — and its setuptools — in place. It also covers flash-attn: with the runtime torch present, `setup.py` resolves a prebuilt wheel from its torch version and C++ ABI flag instead of invoking `nvcc`.

Verified with a cold cache built from scratch: `--all-extras`, `--extra accel` alone, and `--extra deepspeed` alone all install; zero build failures; zero `nvcc`/`ninja` lines. `flash_attn_func` runs on CUDA and `import deepspeed` works. `uv.lock` only gains markers — no version changes (1038 artifact hashes unchanged).

## README, and the zh / ja / es / ar translations

| Problem | Detail |
| --- | --- |
| `examples/09.wav` does not exist | The demo space 404s it and it is absent from `cases.jsonl`; the on-demand download provides `voice_09.wav`. Same typo in all translations. |
| `huggingface-hub[cli,hf_xet]` warns | Modern `huggingface-hub` has no `cli` extra: `warning: The package huggingface-hub==1.27.0 does not have an extra named cli`. |
| `uv run indextts/infer_v2.py` cannot work | It is a benchmark loop hardcoded to `checkpoints/`, so with the documented `checkpoints_2` layout it dies on `ValueError: vocab_file checkpoints/bpe.model does not exist`. Removed in favour of the Python API. |
| Example audio never arrives for script users | `ensure_examples_available()` is called only by `webui.py`, but `infer_v2_5.py` defaults `--prompt_wav` to `examples/voice_01.wav` — a fresh clone raises `FileNotFoundError`. Documented, with a one-liner to fetch it. |
| Emotion-from-text examples raise | `use_emo_text=True` requires `use_qwen_emo=True` at construction, which the init example omits. Confirmed: fails as written, passes once the flag is set. |

The other 9 Python examples were executed as written and produce audio (pinyin / CMU / kana pronunciation control included).

## `webui.py`

The title and arXiv badge were hardcoded, so the 2.5 UI announced itself as IndexTTS2 and linked the 2.0 paper. Now version-derived — 2.5 points at arXiv 2601.03888. Verified from the served Gradio config: `title: IndexTTS-2.5 Demo`, `<h2><center>IndexTTS-2.5`, `ArXiv-2601.03888`.

## Not addressed here

`uv pip check` reports `deepspeed requires nvidia-ml-py, but it's not installed`. That gap predates this change (absent from the lockfile before and after) and does not affect inference, so it is left alone.