### PR TITLE
webui: adapt precision and QwenEmotion loading to available VRAM

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -139,6 +139,8 @@ if LOW_VRAM:
 
 def build_tts(use_accel=False, use_torch_compile=False):
     """Build an IndexTTS2 instance with the requested acceleration options."""
+    import torch
+
     kwargs = dict(
         model_dir=cmd_args.model_dir,
         cfg_path=os.path.join(cmd_args.model_dir, "config.yaml"),
@@ -149,7 +151,10 @@ def build_tts(use_accel=False, use_torch_compile=False):
         use_qwen_emo=LOAD_QWEN_EMO,
     )
     if IS_V25:
-        kwargs["use_bf16"] = HALF_PRECISION
+        use_bf16 = HALF_PRECISION and torch.cuda.is_bf16_supported()
+        if HALF_PRECISION and not use_bf16:
+            print(">> BF16 is not supported on this device, falling back to full precision.")
+        kwargs["use_bf16"] = use_bf16
     else:
         kwargs["use_fp16"] = HALF_PRECISION
     return IndexTTS2(**kwargs)
@@ -367,6 +372,8 @@ def on_preset_load(name):
         if emo_method >= len(emo_choices):
             gr.Warning(i18n("该预设使用了情感描述文本控制，当前显存不足未加载该模型，已重置为默认方式"))
             emo_method = 0
+            is_experimental = False
+            emo_choices = EMO_CHOICES_OFFICIAL
 
         return {
             experimental_checkbox: gr.update(value=is_experimental),

--- a/webui.py
+++ b/webui.py
@@ -31,6 +31,7 @@ parser.add_argument("--deepspeed", action="store_true", default=False, help="Use
 parser.add_argument("--cuda_kernel", action="store_true", default=False, help="Use CUDA kernel for inference if available")
 parser.add_argument("--accel", action="store_true", default=False, help="Use GPT2 acceleration engine if available")
 parser.add_argument("--torch_compile", action="store_true", default=False, help="Use torch.compile to optimize s2mel if available")
+parser.add_argument("--qwen_emo", action="store_true", default=False, help="Load QwenEmotion even on a low-VRAM GPU, where it is skipped by default")
 parser.add_argument("--gui_seg_tokens", type=int, default=120, help="GUI: Max tokens per generation segment")
 cmd_args = parser.parse_args()
 
@@ -109,6 +110,33 @@ MODE = 'local'
 # Download example audio files if missing
 ensure_examples_available()
 
+LOW_VRAM_THRESHOLD_GB = 10.0
+
+
+def detect_vram_gb():
+    import torch
+
+    if not torch.cuda.is_available():
+        return None
+    return torch.cuda.get_device_properties(0).total_memory / (1024 ** 3)
+
+
+_vram_gb = detect_vram_gb()
+LOW_VRAM = _vram_gb is not None and _vram_gb < LOW_VRAM_THRESHOLD_GB
+
+HALF_PRECISION = cmd_args.fp16 or LOW_VRAM
+LOAD_QWEN_EMO = cmd_args.qwen_emo or not LOW_VRAM
+
+if LOW_VRAM:
+    print(
+        f">> {_vram_gb:.1f} GB VRAM detected (< {LOW_VRAM_THRESHOLD_GB:.0f} GB): "
+        "enabling half precision"
+        + ("" if LOAD_QWEN_EMO else " and skipping QwenEmotion")
+    )
+    if not LOAD_QWEN_EMO:
+        print(">> Emotion control from a text description is unavailable; pass --qwen_emo to force it.")
+
+
 def build_tts(use_accel=False, use_torch_compile=False):
     """Build an IndexTTS2 instance with the requested acceleration options."""
     kwargs = dict(
@@ -118,12 +146,12 @@ def build_tts(use_accel=False, use_torch_compile=False):
         use_cuda_kernel=cmd_args.cuda_kernel,
         use_accel=use_accel,
         use_torch_compile=use_torch_compile,
+        use_qwen_emo=LOAD_QWEN_EMO,
     )
     if IS_V25:
-        kwargs["use_bf16"] = cmd_args.fp16
-        kwargs["use_qwen_emo"] = True
+        kwargs["use_bf16"] = HALF_PRECISION
     else:
-        kwargs["use_fp16"] = cmd_args.fp16
+        kwargs["use_fp16"] = HALF_PRECISION
     return IndexTTS2(**kwargs)
 
 
@@ -138,6 +166,7 @@ EMO_CHOICES_ALL = [i18n("与音色参考音频相同"),
                 i18n("使用情感向量控制"),
                 i18n("使用情感描述文本控制")]
 EMO_CHOICES_OFFICIAL = EMO_CHOICES_ALL[:-1]  # skip experimental features
+EMO_CHOICES_EXPERIMENTAL = EMO_CHOICES_ALL if LOAD_QWEN_EMO else EMO_CHOICES_OFFICIAL
 
 os.makedirs("outputs/tasks",exist_ok=True)
 os.makedirs("prompts",exist_ok=True)
@@ -176,7 +205,7 @@ with open("examples/cases.jsonl", "r", encoding="utf-8") as f:
         example_cases.append(case)
 
 def get_example_cases(include_experimental = False):
-    if include_experimental:
+    if include_experimental and LOAD_QWEN_EMO:
         return example_cases  # show every example
 
     # exclude emotion control mode 3 (emotion from text description)
@@ -334,7 +363,10 @@ def on_preset_load(name):
             emo_vec = emo_vec[:8]
 
         # Update the radio choices when loading an experimental preset.
-        emo_choices = EMO_CHOICES_ALL if is_experimental else EMO_CHOICES_OFFICIAL
+        emo_choices = EMO_CHOICES_EXPERIMENTAL if is_experimental else EMO_CHOICES_OFFICIAL
+        if emo_method >= len(emo_choices):
+            gr.Warning(i18n("该预设使用了情感描述文本控制，当前显存不足未加载该模型，已重置为默认方式"))
+            emo_method = 0
 
         return {
             experimental_checkbox: gr.update(value=is_experimental),
@@ -1116,7 +1148,7 @@ with gr.Blocks(
 
     def on_experimental_change(is_experimental, current_mode_index):
         # 切换情感控制选项
-        new_choices = EMO_CHOICES_ALL if is_experimental else EMO_CHOICES_OFFICIAL
+        new_choices = EMO_CHOICES_EXPERIMENTAL if is_experimental else EMO_CHOICES_OFFICIAL
         # if their current mode selection doesn't exist in new choices, reset to 0.
         # we don't verify that OLD index means the same in NEW list, since we KNOW it does.
         new_index = current_mode_index if current_mode_index < len(new_choices) else 0


### PR DESCRIPTION
`webui.py` hardcodes `use_qwen_emo=True` and ties precision to `--fp16`, which defaults off. A small card therefore gets the single most expensive configuration available, and the failure arrives after the model download rather than before it.

## Measurements

Peak reserved memory for one short utterance, on a 4090:

| Configuration | Peak |
| --- | --- |
| full precision + QwenEmotion (current default) | 8.15 GB |
| half precision + QwenEmotion | 6.54 GB |
| half precision, QwenEmotion skipped | 5.48 GB |

Peak alone does not tell you whether a given card works, so the same three were re-run under a hard per-process cap via `torch.cuda.set_per_process_memory_fraction`:

| Cap | full + Qwen | half + Qwen | half, no Qwen |
| --- | --- | --- | --- |
| 8 GB | completes, peaking at exactly 8.00 GB | ok (6.56 GB) | ok (5.45 GB) |
| 6 GB | OOM | OOM | ok (5.44 GB) |
| 5 GB | — | — | OOM |

An 8 GB card does run the current default — but only by peaking at exactly its whole budget, leaving nothing for the display output and driver overhead a real card also has to fund. A 6 GB card runs only the last column. The floor sits between 5 and 6 GB.

Two caveats on the numbers, since the box was shared: the failing 6 GB runs had ~6.2 GB physically free, so the cap was not the sole binding constraint there — immaterial, as those configurations need 7.70 GB and 6.13 GB just to load. The 5 GB run had 7.19 GB free and failed purely on the cap.

## Change

Below 10 GB, enable half precision and skip QwenEmotion. The threshold is not new — `infer_v2_5.py:123-130` already applies the same 10 GB cutoff to decide on text chunking, so this reuses an existing notion of "small card" rather than inventing one.

`--qwen_emo` forces the model back on for someone who knows their card can take it. Note it will not fit in 6 GB.

Skipping QwenEmotion removes emotion-control-from-text, so the UI is gated on it too: mode 3 disappears from the experimental choices, its examples are filtered out, and a preset saved with it resets to the default with a warning. Without that gating, selecting mode 3 raises `use_emo_text=True requires QwenEmotion, but it was not loaded at init` from `infer_v2_5.py` — after the user has already typed their text.

## Verification

All three configurations were started for real and each reported the intended decision, with process memory matching the table:

| Case | Startup output | Process memory |
| --- | --- | --- |
| threshold 10, 23.6 GB card | nothing (branch not taken) | 8326 MiB |
| threshold raised so the card counts as small | `enabling half precision and skipping QwenEmotion`, plus `QwenEmotion not loaded (use_qwen_emo=False)` from the model layer | 5596 MiB |
| same, with `--qwen_emo` | `enabling half precision`, without the skip suffix | 6726 MiB |

The second case's model-layer line confirms the flag reaches `IndexTTS2`, not just the log.

Only `webui.py` changes; no new parameter was needed, as `use_qwen_emo` already exists on both `infer_v2_5.py` and `infer_v2.py`.