### PR TITLE
docs: point the vLLM recipe links at the published page

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Japanese Kana), and faster inference than IndexTTS-2.
   - Now supports Chinese, English, Japanese, Spanish and Arabic, with faster inference than IndexTTS-2, while keeping the cross-lingual and timbre-emotion disentanglement capabilities.
   - Improved controllability of Chinese Pinyin, English CMU phonemes and Japanese Kana.
   - Speaking speed control via `duration_factor` (0.5x–2.0x duration).
-  - Production deployment supported via [vLLM](https://github.com/vllm-project/recipes/pull/772).
+  - Production deployment supported via [vLLM](https://recipes.vllm.ai/IndexTeam/IndexTTS-2.5).
 - `2025/09/08` 🔥 We release **IndexTTS-2**
   - The first autoregressive TTS model with precise synthesis duration control, supporting both controllable and uncontrollable modes. <i>This functionality is not yet enabled in this release.</i>
   - Highly expressive emotional speech synthesis, with emotion control through multiple input modalities.
@@ -200,7 +200,7 @@ uv run webui.py -h
 
 ### 🚀 Serving with vLLM
 
-For production deployment, see the [vLLM recipe for IndexTTS](https://github.com/vllm-project/recipes/pull/772).
+For production deployment, see the [vLLM recipe for IndexTTS](https://recipes.vllm.ai/IndexTeam/IndexTTS-2.5).
 
 ### 📝 Python API
 

--- a/docs/README_ar.md
+++ b/docs/README_ar.md
@@ -196,7 +196,7 @@ uv run webui.py -h
 
 ### 🚀 التشغيل باستخدام vLLM
 
-للنشر الإنتاجي، راجع [وصفة vLLM لـ IndexTTS](https://github.com/vllm-project/recipes/pull/772).
+للنشر الإنتاجي، راجع [وصفة vLLM لـ IndexTTS](https://recipes.vllm.ai/IndexTeam/IndexTTS-2.5).
 
 ### 📝 واجهة Python البرمجية
 

--- a/docs/README_es.md
+++ b/docs/README_es.md
@@ -206,7 +206,7 @@ uv run webui.py -h
 
 ### 🚀 Servicio con vLLM
 
-Para el despliegue en producción, consulta la [receta de vLLM para IndexTTS](https://github.com/vllm-project/recipes/pull/772).
+Para el despliegue en producción, consulta la [receta de vLLM para IndexTTS](https://recipes.vllm.ai/IndexTeam/IndexTTS-2.5).
 
 ### 📝 API de Python
 

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -199,7 +199,7 @@ uv run webui.py -h
 
 ### 🚀 vLLM によるサービング
 
-本番環境へのデプロイについては、[IndexTTS 向け vLLM レシピ](https://github.com/vllm-project/recipes/pull/772)を参照してください。
+本番環境へのデプロイについては、[IndexTTS 向け vLLM レシピ](https://recipes.vllm.ai/IndexTeam/IndexTTS-2.5)を参照してください。
 
 ### 📝 Python API
 

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -37,7 +37,7 @@ IndexTTS 是一个零样本文本转语音（TTS）系统，只需一段参考�
   - 模型现已支持中文、英文、日语、西班牙语和阿拉伯语，推理速度较 IndexTTS-2 更快，同时保持跨语言合成与音色-情感解耦能力。
   - 模型提升了中文拼音、英文 CMU 音素和日语假名的可控性。
   - 支持通过 `duration_factor` 控制语速（0.5–2.0 倍时长）。
-  - 支持通过 [vLLM](https://github.com/vllm-project/recipes/pull/772) 进行生产环境部署。
+  - 支持通过 [vLLM](https://recipes.vllm.ai/IndexTeam/IndexTTS-2.5) 进行生产环境部署。
 - `2025/09/08` 🔥 **IndexTTS-2** 全球发布！
   - 首个支持精确合成时长控制的自回归 TTS 模型，支持可控与非可控模式。<i>本版本暂未开放该功能。</i>
   - 模型实现高度情感表达的语音合成，支持多模态情感控制。
@@ -186,7 +186,7 @@ uv run webui.py -h
 
 ### 🚀 使用 vLLM 部署
 
-生产环境部署请参考 [IndexTTS 的 vLLM 部署方案](https://github.com/vllm-project/recipes/pull/772)。
+生产环境部署请参考 [IndexTTS 的 vLLM 部署方案](https://recipes.vllm.ai/IndexTeam/IndexTTS-2.5)。
 
 ### 📝 Python 脚本调用
 


### PR DESCRIPTION
The vLLM recipe has landed upstream, so the READMEs no longer need to link to the pull request that introduced it.

Replaces `https://github.com/vllm-project/recipes/pull/772` with `https://recipes.vllm.ai/IndexTeam/IndexTTS-2.5` — seven occurrences across the English, Chinese, Japanese, Spanish and Arabic READMEs.

Verified the new URL before switching: it returns 200 and titles itself `IndexTeam/IndexTTS-2.5 | vLLM Recipes`. No occurrences of the old link remain anywhere in the tree.

Docs only.