### PR TITLE
Fix BigVGAN CUDA architecture selection

### DIFF
--- a/indextts/s2mel/modules/bigvgan/alias_free_activation/cuda/load.py
+++ b/indextts/s2mel/modules/bigvgan/alias_free_activation/cuda/load.py
@@ -3,25 +3,11 @@
 
 import os
 import pathlib
-import subprocess
 
 from torch.utils import cpp_extension
 
-"""
-Setting this param to a list has a problem of generating different compilation commands (with diferent order of architectures) and leading to recompilation of fused kernels. 
-Set it to empty stringo avoid recompilation and assign arch flags explicity in extra_cuda_cflags below
-"""
-os.environ["TORCH_CUDA_ARCH_LIST"] = ""
-
 
 def load():
-    # Check if cuda 11 is installed for compute capability 8.0
-    cc_flag = []
-    _, bare_metal_major, _ = _get_cuda_bare_metal_version(cpp_extension.CUDA_HOME)
-    if int(bare_metal_major) >= 11:
-        cc_flag.append("-gencode")
-        cc_flag.append("arch=compute_80,code=sm_80")
-
     # Build path
     srcpath = pathlib.Path(__file__).parent.absolute()
     buildpath = srcpath / "build"
@@ -29,6 +15,8 @@ def load():
 
     # Helper function to build the kernels.
     def _cpp_extention_load_helper(name, sources, extra_cuda_flags):
+        # PyTorch's generated -gencode flags honor TORCH_CUDA_ARCH_LIST, or
+        # detect visible GPUs when the variable is not set.
         return cpp_extension.load(
             name=name,
             sources=sources,
@@ -38,12 +26,9 @@ def load():
             ],
             extra_cuda_cflags=[
                 "-O3",
-                "-gencode",
-                "arch=compute_70,code=sm_70",
                 "--use_fast_math",
             ]
-            + extra_cuda_flags
-            + cc_flag,
+            + extra_cuda_flags,
             verbose=True,
         )
 
@@ -63,19 +48,6 @@ def load():
     )
 
     return anti_alias_activation_cuda
-
-
-def _get_cuda_bare_metal_version(cuda_dir):
-    raw_output = subprocess.check_output(
-        [cuda_dir + "/bin/nvcc", "-V"], universal_newlines=True
-    )
-    output = raw_output.split()
-    release_idx = output.index("release") + 1
-    release = output[release_idx].split(".")
-    bare_metal_major = release[0]
-    bare_metal_minor = release[1][0]
-
-    return raw_output, bare_metal_major, bare_metal_minor
 
 
 def _create_build_dir(buildpath):


### PR DESCRIPTION
## Description

Remove the hard-coded SM70 and SM80 targets from the BigVGAN CUDA
extension build.

The loader previously cleared `TORCH_CUDA_ARCH_LIST`, always compiled
for SM70, and additionally compiled for SM80 when CUDA 11 or newer was
installed. Newer CUDA toolkits may no longer support SM70, causing the
entire extension build to fail even when the active GPU uses a supported
architecture.

Let `torch.utils.cpp_extension` select the compilation targets instead:

- Honor `TORCH_CUDA_ARCH_LIST` when it is set.
- Detect all currently visible GPU architectures when it is not set.
- Preserve the existing Torch fallback when the custom extension cannot
  be loaded.

This is a general architecture-selection fix and is not specific to a
particular GPU model.

Related to #468.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation / comments only
- [ ] Build / CI / dependency change
- [ ] Refactor (no behaviour change)

## How has this been tested?

Test environment:

- PyTorch 2.8.0+cu128
- CUDA Toolkit 13.0
- NVIDIA RTX 2080 Ti (SM75)
- NVIDIA A16 (SM86)

With `TORCH_CUDA_ARCH_LIST=7.5`, the generated command contained only:

```text
-gencode=arch=compute_75,code=sm_75
```

With both SM75 and SM86 GPUs visible and `TORCH_CUDA_ARCH_LIST` unset,
PyTorch generated:

```text
-gencode=arch=compute_75,code=sm_75
-gencode=arch=compute_86,code=compute_86
-gencode=arch=compute_86,code=sm_86
```

The fused activation forward pass completed successfully on both an RTX
2080 Ti and an A16. The full application also loaded successfully with:

```bash
uv run webui.py --deepspeed --cuda_kernel --port 17860
```

The startup log confirmed:

```text
>> Preload custom CUDA kernel for BigVGAN
```

The non-GPU test suite also passes:

```bash
uv run pytest -m "not gpu"
```

Result: `153 passed, 22 deselected`.

## Checklist

- [x] Tests pass locally: `uv run pytest -m "not gpu"` (no GPU) or `uv run pytest tests/test_v2.py` (with GPU)
- [x] I have added or updated tests to cover my changes (not applicable; verified with clean JIT builds and fused forward tests on SM75 and SM86).
- [x] I have added or updated docstrings for any changed public functions (not applicable; no public API changed).

## Screenshots / output (if relevant)

```text
>> Preload custom CUDA kernel for BigVGAN
SM75_FORWARD_OK (1, 4, 32) torch.float32 cuda:0 True
SM86_FORWARD_OK (1, 4, 32) torch.float32 cuda:2 True
```
