### PR TITLE
fix: align GPT latent with decoded semantic features in IndexTTS 2.5

### DIFF
--- a/indextts/infer_v2_5.py
+++ b/indextts/infer_v2_5.py
@@ -72,6 +72,17 @@ def apply_pronunciation_annotations(text: str) -> str:
     return PRONUNCIATION_ANNOTATION_PATTERN.sub(_replace, text)
 
 
+def _align_gpt_latent_to_semantic(latent: torch.Tensor, target_length: int) -> torch.Tensor:
+    """Match GPT latent time steps to the decoded semantic feature length."""
+    if latent.shape[1] == target_length:
+        return latent
+    return F.interpolate(
+        latent.transpose(1, 2),
+        size=target_length,
+        mode="nearest",
+    ).transpose(1, 2)
+
+
 class IndexTTS2:
     def __init__(
             self, cfg_path="checkpoints/config.yaml", model_dir="checkpoints", use_bf16=False, device=None,
@@ -852,14 +863,9 @@ class IndexTTS2:
                     if self.use_gpt_latent:
                         latent = self.s2mel.models['gpt_layer'](latent)
                         # EnhancedCodec upsamples decoded semantic features by 2x,
-                        # while GPT latent stays at the code-token rate.
-                        if latent.shape[1] != S_infer.shape[1]:
-                            latent = F.interpolate(
-                                latent.transpose(1, 2),
-                                size=S_infer.shape[1],
-                                mode="linear",
-                                align_corners=False,
-                            ).transpose(1, 2)
+                        # while GPT latent stays at the code-token rate. Match the
+                        # codec's nearest-neighbor temporal expansion.
+                        latent = _align_gpt_latent_to_semantic(latent, S_infer.shape[1])
                         S_infer = S_infer + latent
                     target_lengths = torch.LongTensor([int(S_infer.shape[1] * 1.72 * duration_factor)]).to(codes.device)
 

--- a/indextts/infer_v2_5.py
+++ b/indextts/infer_v2_5.py
@@ -851,6 +851,15 @@ class IndexTTS2:
                     S_infer = self.semantic_codec.decode(codes)
                     if self.use_gpt_latent:
                         latent = self.s2mel.models['gpt_layer'](latent)
+                        # EnhancedCodec upsamples decoded semantic features by 2x,
+                        # while GPT latent stays at the code-token rate.
+                        if latent.shape[1] != S_infer.shape[1]:
+                            latent = F.interpolate(
+                                latent.transpose(1, 2),
+                                size=S_infer.shape[1],
+                                mode="linear",
+                                align_corners=False,
+                            ).transpose(1, 2)
                         S_infer = S_infer + latent
                     target_lengths = torch.LongTensor([int(S_infer.shape[1] * 1.72 * duration_factor)]).to(codes.device)
 

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -93,6 +93,27 @@ def test_example_download_reachable(tmp_path, monkeypatch):
     assert Path(path).exists() and Path(path).stat().st_size > 0
 
 
+def test_gpt_latent_alignment_uses_codec_temporal_expansion():
+    torch = pytest.importorskip("torch")
+    from indextts.infer_v2_5 import _align_gpt_latent_to_semantic
+
+    latent = torch.tensor([[[1.0], [2.0], [3.0]]])
+    aligned = _align_gpt_latent_to_semantic(latent, 6)
+
+    assert aligned.shape == (1, 6, 1)
+    assert aligned[:, :, 0].tolist() == [[1.0, 1.0, 2.0, 2.0, 3.0, 3.0]]
+
+
+def test_gpt_latent_alignment_keeps_matching_length_tensor():
+    torch = pytest.importorskip("torch")
+    from indextts.infer_v2_5 import _align_gpt_latent_to_semantic
+
+    latent = torch.randn(1, 4, 2)
+    aligned = _align_gpt_latent_to_semantic(latent, 4)
+
+    assert aligned is latent
+
+
 # -- Model download logic (no GPU) --------------------------------------------
 
 def test_legacy_cache_compatibility(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

When `use_gpt_latent=True` is enabled in IndexTTS 2.5, inference fails at `S_infer + latent` because the decoded semantic features and projected GPT latent have different temporal lengths.

With the released 2.5 checkpoint, `EnhancedCodec.decode(codes)` returns 1706 frames while the projected GPT latent returns 853 frames. The 2x mismatch is caused by the codec's temporal upsampling, making the optional GPT latent path unusable.

## Fix

Align the projected GPT latent to the decoded semantic feature length before fusion. The alignment uses `torch.nn.functional.interpolate(..., mode="nearest")`, matching `EnhancedCodec.decode()`'s nearest-neighbor temporal expansion. Equal-length tensors return unchanged. The default path with `use_gpt_latent=False` is unchanged.

## Reproduction

- Model: IndexTTS 2.5 released checkpoint
- Voice: `Intellectual.wav`
- `use_gpt_latent`: `true`
- Text: `你们都是家族的新鲜血液,应该知道今天的测验对你们来说有多重要,测验规矩,第七段斗之气以及其上判为合格,反之,则为不合格,不过,按照以往的额外规定,在测验完毕之后,斗之气七段以下的,有权利向七段以上的同伴发出一次挑战,如果挑战胜利,那也能进入合格区域!`

Before the fix, inference raises:

```text
RuntimeError: The size of tensor a (1706) must match the size of tensor b (853) at non-singleton dimension 1
```

After the fix, the same prompt completes successfully and produces a valid 24.64-second WAV file at 24 kHz.

Two synthesized audio samples are attached for the requested before/after comparison; no other `Intellectual` samples are included:

- Before: [not_use_gpt_latent.wav](https://github.com/user-attachments/files/31019396/not_use_gpt_latent.wav)
- After: [use_gpt_latent.wav](https://github.com/user-attachments/files/31019384/use_gpt_latent.wav)

## Why this is necessary

The `use_gpt_latent` option is exposed by the 2.5 inference API and the released checkpoint contains the corresponding `gpt_layer` weights, but the current implementation cannot execute that path. This patch makes the exposed option operational without changing behavior when it is disabled.

## Validation

- `PYTHONPATH=. ../../.venv/bin/pytest tests/test_v2.py -q`: **18 passed, 12 skipped** (the skipped tests require unavailable model fixtures/GPU).
- Added regression coverage for unequal lengths (nearest expansion) and equal lengths (identity).
- Real 2.5 GPU inference with the prompt above loaded `gpt_layer`, completed both text segments, and no longer hit the 1706/853 shape error.