### PR TITLE
ci: run the lightweight checks on Windows too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,12 @@ permissions:
 
 jobs:
   lightweight-checks:
-    name: Lightweight Python checks
-    runs-on: ubuntu-latest
+    name: Lightweight Python checks (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout
@@ -25,6 +29,12 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
 
       - name: Run tests (no GPU)
+        # Windows exercises dependency markers and platform branches that Linux
+        # never reaches; the CLI tests currently fail there on path resolution,
+        # so it reports without blocking until those are fixed.
+        continue-on-error: ${{ matrix.os == 'windows-latest' }}
         run: uv run --extra test pytest -m "not gpu" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,4 @@ jobs:
           enable-cache: true
 
       - name: Run tests (no GPU)
-        # Windows exercises dependency markers and platform branches that Linux
-        # never reaches; the CLI tests currently fail there on path resolution,
-        # so it reports without blocking until those are fixed.
-        continue-on-error: ${{ matrix.os == 'windows-latest' }}
         run: uv run --extra test pytest -m "not gpu" -v

--- a/cli_tests/test_cli_v2_batch.py
+++ b/cli_tests/test_cli_v2_batch.py
@@ -132,7 +132,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_dry_run_validates_manifest_without_loading_model(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             batch_dir = temp_path / "batch"
             batch_dir.mkdir()
@@ -165,7 +165,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_dry_run_rejects_non_object_json_with_1_based_line_number(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             batch_file = temp_path / "batch.jsonl"
             batch_file.write_text('\n["not", "an", "object"]\n', encoding="utf-8")
@@ -188,7 +188,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_dry_run_rejects_unknown_fields(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -217,7 +217,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_dry_run_rejects_conflicting_text_sources(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             text_path = temp_path / "input.txt"
@@ -247,7 +247,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_dry_run_rejects_missing_output(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -272,7 +272,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_dry_run_rejects_duplicate_output_paths_with_line_number(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -306,7 +306,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_dry_run_resolves_text_file_and_voice_relative_to_batch_file_directory(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             batch_dir = temp_path / "batch"
             assets_dir = batch_dir / "assets"
@@ -343,7 +343,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_dry_run_checks_model_files_without_importing_runtime_packages(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             batch_file = temp_path / "batch.jsonl"
             voice_path = temp_path / "voice.wav"
@@ -371,7 +371,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_dry_run_with_force_still_rejects_duplicate_output_paths(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -406,7 +406,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_concat_dry_run_validates_manifest_without_loading_model_or_creating_output_parent(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             batch_dir = temp_path / "batch"
             batch_dir.mkdir()
@@ -460,7 +460,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
         for extra_args, expected_message in cases:
             with self.subTest(expected_message=expected_message):
                 with tempfile.TemporaryDirectory() as temp_dir:
-                    temp_path = Path(temp_dir)
+                    temp_path = Path(temp_dir).resolve()
                     model_dir = make_model_dir(temp_path)
                     voice_path = temp_path / "voice.wav"
                     batch_file = temp_path / "batch.jsonl"
@@ -485,7 +485,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_concat_enforces_row_output_and_silence_after_ms_contracts(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -558,7 +558,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_concat_generates_final_wav_and_cleans_temp_dir_by_default(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -605,7 +605,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_concat_keep_temp_preserves_temp_dir_after_success(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -645,7 +645,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_concat_stops_on_inference_failure_and_cleans_temp_dir_by_default(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -693,7 +693,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_concat_keep_temp_preserves_temp_dir_after_inference_failure(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -741,7 +741,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_concat_rejects_mismatched_generated_segment_format_and_cleans_temp_dir(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -785,7 +785,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_concat_temp_cleanup_failure_does_not_override_inference_failure(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -837,7 +837,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_concat_temp_cleanup_failure_after_success_returns_inference_error(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -885,7 +885,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_concat_dry_run_rejects_final_output_path_conflicts_without_side_effects(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -953,7 +953,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_concat_dry_run_rejects_final_output_that_matches_batch_file(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.wav"
@@ -983,7 +983,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
 
     def test_batch_concat_dry_run_rejects_final_output_that_matches_empty_batch_file(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             batch_file = temp_path / "batch.wav"
             batch_file.write_text("", encoding="utf-8")
@@ -1017,7 +1017,7 @@ class BatchCommandDryRunTests(unittest.TestCase):
         for manifest, expected_message in cases:
             with self.subTest(expected_message=expected_message):
                 with tempfile.TemporaryDirectory() as temp_dir:
-                    temp_path = Path(temp_dir)
+                    temp_path = Path(temp_dir).resolve()
                     model_dir = make_model_dir(temp_path)
                     voice_path = temp_path / "voice.wav"
                     batch_file = temp_path / "batch.jsonl"
@@ -1069,7 +1069,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_executes_tasks_in_order_with_one_model_initialization_and_summary(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             batch_dir = temp_path / "batch"
             batch_dir.mkdir()
@@ -1127,7 +1127,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_auto_output_dir_generates_numbered_outputs(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             batch_dir = temp_path / "batch"
             output_dir = temp_path / "auto"
@@ -1187,7 +1187,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_auto_output_dir_rejects_generated_output_that_conflicts_with_inputs_even_with_force(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             output_dir = temp_path / "auto"
             output_dir.mkdir()
@@ -1221,7 +1221,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_auto_output_dir_rejects_generated_output_that_conflicts_with_batch_file_even_with_force(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             output_dir = temp_path / "auto"
             output_dir.mkdir()
@@ -1252,7 +1252,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_auto_output_dir_uses_output_prefix(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             output_dir = temp_path / "auto"
             voice_path = temp_path / "voice.wav"
@@ -1297,7 +1297,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
         for extra_args, expected_message in cases:
             with self.subTest(expected_message=expected_message):
                 with tempfile.TemporaryDirectory() as temp_dir:
-                    temp_path = Path(temp_dir)
+                    temp_path = Path(temp_dir).resolve()
                     model_dir = make_model_dir(temp_path)
                     voice_path = temp_path / "voice.wav"
                     batch_file = temp_path / "batch.jsonl"
@@ -1322,7 +1322,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_auto_output_dir_rejects_row_output(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -1352,7 +1352,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_auto_output_dir_rejects_concat_output_configuration(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -1382,7 +1382,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_auto_output_dir_dry_run_does_not_create_output_dir(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             output_dir = temp_path / "auto"
             voice_path = temp_path / "voice.wav"
@@ -1415,7 +1415,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_auto_output_dir_respects_force_for_existing_external_outputs(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             output_dir = temp_path / "auto"
             output_dir.mkdir()
@@ -1470,7 +1470,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_auto_output_dir_resolves_relative_to_current_working_directory(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             cwd_path = temp_path / "cwd"
             batch_dir = temp_path / "batch"
@@ -1513,7 +1513,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_auto_output_dir_rejects_output_parent_that_is_a_file_during_dry_run(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             blocked_output_dir = temp_path / "blocked"
             voice_path = temp_path / "voice.wav"
@@ -1542,7 +1542,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_maps_command_runtime_options_to_indextts2_once(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             batch_file = temp_path / "batch.jsonl"
             voice_path = temp_path / "voice.wav"
@@ -1601,7 +1601,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_applies_command_defaults_and_row_emotion_overrides(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             batch_dir = temp_path / "batch"
             batch_dir.mkdir()
@@ -1674,7 +1674,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_row_emotion_weight_inherits_command_emotion_source(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
@@ -1720,7 +1720,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_inherits_command_emotion_vector(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
@@ -1762,7 +1762,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_accepts_row_emotion_vector_cli_style_string(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
@@ -1801,7 +1801,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_rejects_row_emotion_weight_without_emotion_source(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -1830,7 +1830,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_rejects_conflicting_row_emotion_sources(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             emotion_path = temp_path / "emotion.wav"
@@ -1860,7 +1860,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_reuses_synth_emotion_vector_validation_for_rows(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -1889,7 +1889,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_rejects_boolean_entries_in_json_emotion_vector(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             batch_file = temp_path / "batch.jsonl"
@@ -1918,7 +1918,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_stops_on_first_inference_failure_and_keeps_prior_outputs(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             batch_file = temp_path / "batch.jsonl"
             voice_path = temp_path / "voice.wav"
@@ -1974,7 +1974,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_rejects_existing_external_output_without_force_before_model_initialization(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             batch_file = temp_path / "batch.jsonl"
             voice_path = temp_path / "voice.wav"
@@ -2007,7 +2007,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_force_allows_existing_external_output(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             batch_file = temp_path / "batch.jsonl"
             voice_path = temp_path / "voice.wav"
@@ -2046,7 +2046,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_rejects_runtime_options_inside_batch_rows(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             batch_file = temp_path / "batch.jsonl"
             voice_path = temp_path / "voice.wav"
@@ -2075,7 +2075,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_returns_resource_error_when_model_directory_is_missing(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             batch_file = temp_path / "batch.jsonl"
             voice_path = temp_path / "voice.wav"
             missing_model_dir = temp_path / "missing-models"
@@ -2103,7 +2103,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_returns_resource_error_with_download_help_when_model_file_is_missing(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = temp_path / "models"
             batch_file = temp_path / "batch.jsonl"
             voice_path = temp_path / "voice.wav"
@@ -2133,7 +2133,7 @@ class BatchCommandExecutionTests(unittest.TestCase):
 
     def test_batch_returns_runtime_error_when_indextts2_import_fails(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             batch_file = temp_path / "batch.jsonl"
             voice_path = temp_path / "voice.wav"

--- a/cli_tests/test_cli_v2_check.py
+++ b/cli_tests/test_cli_v2_check.py
@@ -146,7 +146,7 @@ class CheckCommandTests(unittest.TestCase):
 
     def test_check_returns_success_when_resources_packages_and_requested_device_are_available(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            model_dir = make_model_dir(Path(temp_dir))
+            model_dir = make_model_dir(Path(temp_dir).resolve())
 
             with patched_imports(fake_torch(cuda=True)):
                 from indextts.cli_v2 import main
@@ -166,7 +166,7 @@ class CheckCommandTests(unittest.TestCase):
 
     def test_check_returns_resource_error_when_model_directory_is_missing(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            missing_model_dir = Path(temp_dir) / "missing"
+            missing_model_dir = Path(temp_dir).resolve() / "missing"
 
             from indextts.cli_v2 import main
 
@@ -182,7 +182,7 @@ class CheckCommandTests(unittest.TestCase):
 
     def test_check_returns_resource_error_when_required_model_files_are_missing(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            model_dir = Path(temp_dir) / "checkpoints"
+            model_dir = Path(temp_dir).resolve() / "checkpoints"
             model_dir.mkdir()
             (model_dir / "config.yaml").write_text("placeholder", encoding="utf-8")
 
@@ -202,7 +202,7 @@ class CheckCommandTests(unittest.TestCase):
 
     def test_check_requires_the_full_key_model_resource_set(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            model_dir = Path(temp_dir) / "checkpoints"
+            model_dir = Path(temp_dir).resolve() / "checkpoints"
             model_dir.mkdir()
             for filename in [
                 "config.yaml",
@@ -228,7 +228,7 @@ class CheckCommandTests(unittest.TestCase):
 
     def test_check_requires_the_auxiliary_model_cache_resources(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            model_dir = make_model_dir(Path(temp_dir), include_aux=False)
+            model_dir = make_model_dir(Path(temp_dir).resolve(), include_aux=False)
 
             from indextts.cli_v2 import main
 
@@ -248,7 +248,7 @@ class CheckCommandTests(unittest.TestCase):
 
     def test_check_requires_file_resources_and_directory_resources(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            model_dir = Path(temp_dir) / "checkpoints"
+            model_dir = Path(temp_dir).resolve() / "checkpoints"
             model_dir.mkdir()
             for filename in REQUIRED_MODEL_FILES:
                 if filename == "gpt.pth":
@@ -271,7 +271,7 @@ class CheckCommandTests(unittest.TestCase):
 
     def test_check_returns_runtime_error_when_required_python_package_is_missing(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            model_dir = make_model_dir(Path(temp_dir))
+            model_dir = make_model_dir(Path(temp_dir).resolve())
 
             with patched_missing_import("torchaudio", fake_torch(cuda=True)):
                 from indextts.cli_v2 import main
@@ -288,7 +288,7 @@ class CheckCommandTests(unittest.TestCase):
 
     def test_check_returns_runtime_error_when_requested_device_is_unavailable(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            model_dir = make_model_dir(Path(temp_dir))
+            model_dir = make_model_dir(Path(temp_dir).resolve())
 
             with patched_imports(fake_torch(cuda=False)):
                 from indextts.cli_v2 import main
@@ -304,7 +304,7 @@ class CheckCommandTests(unittest.TestCase):
 
     def test_check_returns_runtime_error_when_requested_cuda_index_does_not_exist(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            model_dir = make_model_dir(Path(temp_dir))
+            model_dir = make_model_dir(Path(temp_dir).resolve())
 
             with patched_imports(fake_torch(cuda=True, cuda_device_count=1)):
                 from indextts.cli_v2 import main
@@ -320,7 +320,7 @@ class CheckCommandTests(unittest.TestCase):
 
     def test_check_returns_runtime_error_when_requested_xpu_index_does_not_exist(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            model_dir = make_model_dir(Path(temp_dir))
+            model_dir = make_model_dir(Path(temp_dir).resolve())
 
             with patched_imports(fake_torch(xpu=True, xpu_device_count=1)):
                 from indextts.cli_v2 import main
@@ -388,7 +388,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_generates_audio_from_inline_text(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -438,7 +438,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_generates_audio_from_utf8_text_file(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             text_path = temp_path / "input.txt"
             output_path = temp_path / "out.wav"
@@ -465,7 +465,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_generates_audio_from_stdin(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -490,7 +490,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_uses_emotion_audio_and_weight(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             emotion_path = temp_path / "emotion.wav"
             output_path = temp_path / "out.wav"
@@ -524,7 +524,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_uses_emotion_text_and_weight(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -556,7 +556,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_uses_emotion_vector_and_weight(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -589,7 +589,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_accepts_python_list_style_emotion_vector(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -617,7 +617,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_does_not_rewrite_valid_emotion_vector(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -644,7 +644,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_input_error_when_emotion_vector_is_empty(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -682,7 +682,7 @@ class SynthCommandTests(unittest.TestCase):
         for vector, expected_error in cases:
             with self.subTest(vector=vector):
                 with tempfile.TemporaryDirectory() as temp_dir:
-                    temp_path = Path(temp_dir)
+                    temp_path = Path(temp_dir).resolve()
                     voice_path = temp_path / "voice.wav"
                     output_path = temp_path / "out.wav"
                     voice_path.write_bytes(b"voice")
@@ -712,7 +712,7 @@ class SynthCommandTests(unittest.TestCase):
         for other_emotion_args in (["--emotion-audio"], ["--emotion-text", "warm and calm"]):
             with self.subTest(other_emotion_args=other_emotion_args):
                 with tempfile.TemporaryDirectory() as temp_dir:
-                    temp_path = Path(temp_dir)
+                    temp_path = Path(temp_dir).resolve()
                     voice_path = temp_path / "voice.wav"
                     emotion_path = temp_path / "emotion.wav"
                     output_path = temp_path / "out.wav"
@@ -743,7 +743,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_input_error_when_emotion_text_is_empty(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -770,7 +770,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_input_error_when_emotion_sources_conflict(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             emotion_path = temp_path / "emotion.wav"
             output_path = temp_path / "out.wav"
@@ -801,7 +801,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_input_error_when_empty_emotion_audio_conflicts_with_emotion_text(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -830,7 +830,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_resource_error_when_emotion_audio_is_missing(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             emotion_path = temp_path / "missing-emotion.wav"
             output_path = temp_path / "out.wav"
@@ -859,7 +859,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_input_error_when_emotion_weight_is_not_a_float(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             emotion_path = temp_path / "emotion.wav"
             output_path = temp_path / "out.wav"
@@ -890,7 +890,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_input_error_when_text_source_is_missing(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -913,7 +913,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_input_error_when_text_sources_conflict(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             text_path = temp_path / "input.txt"
             output_path = temp_path / "out.wav"
@@ -942,7 +942,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_input_error_when_empty_text_source_conflicts_with_stdin(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -969,7 +969,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_input_error_when_text_is_empty_after_trimming(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -994,7 +994,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_resource_error_when_text_file_is_missing(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             text_path = temp_path / "missing.txt"
             output_path = temp_path / "out.wav"
@@ -1021,7 +1021,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_resource_error_when_voice_file_is_missing(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "missing.wav"
             output_path = temp_path / "out.wav"
 
@@ -1046,7 +1046,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_input_error_when_voice_argument_is_missing(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             output_path = temp_path / "out.wav"
 
             exit_code, stdout, stderr, calls = self.run_synth(
@@ -1067,7 +1067,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_input_error_when_output_exists_without_force(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -1094,7 +1094,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_input_error_when_output_argument_is_missing(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             voice_path.write_bytes(b"voice")
 
@@ -1116,7 +1116,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_allows_existing_output_when_force_is_set(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -1143,7 +1143,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_creates_output_parent_directory(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "nested" / "audio" / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -1170,7 +1170,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_maps_runtime_options_to_indextts2(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
@@ -1219,7 +1219,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_inference_error_when_indextts2_infer_fails(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -1246,7 +1246,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_inference_error_when_indextts2_initialization_fails(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -1272,7 +1272,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_resource_error_when_model_directory_is_missing(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             missing_model_dir = temp_path / "missing-models"
@@ -1302,7 +1302,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_resource_error_when_model_file_is_missing(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = temp_path / "models"
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
@@ -1335,7 +1335,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_returns_runtime_error_when_indextts2_import_fails(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             model_dir = make_model_dir(temp_path)
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
@@ -1367,7 +1367,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_load_indextts2_points_huggingface_cache_at_model_resource_directory(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            model_dir = Path(temp_dir) / "models"
+            model_dir = Path(temp_dir).resolve() / "models"
 
             class FakeIndexTTS2:
                 pass
@@ -1388,7 +1388,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_suppresses_model_stdout_when_not_verbose(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")
@@ -1416,7 +1416,7 @@ class SynthCommandTests(unittest.TestCase):
 
     def test_synth_allows_model_stdout_when_verbose(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             voice_path = temp_path / "voice.wav"
             output_path = temp_path / "out.wav"
             voice_path.write_bytes(b"voice")

--- a/cli_tests/test_cli_v2_concat.py
+++ b/cli_tests/test_cli_v2_concat.py
@@ -66,7 +66,7 @@ class ConcatCommandDryRunTests(unittest.TestCase):
 
     def test_concat_dry_run_validates_manifest_without_creating_output_parent(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             concat_dir = temp_path / "concat"
             concat_dir.mkdir()
             audio_path = concat_dir / "clip.wav"
@@ -110,7 +110,7 @@ class ConcatCommandDryRunTests(unittest.TestCase):
 
     def test_concat_dry_run_rejects_non_object_json_with_1_based_line_number(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             concat_file = temp_path / "manifest.jsonl"
             concat_file.write_text('\n["not", "an", "object"]\n', encoding="utf-8")
 
@@ -132,7 +132,7 @@ class ConcatCommandDryRunTests(unittest.TestCase):
 
     def test_concat_dry_run_rejects_unknown_fields_and_comment_lines(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             audio_path = temp_path / "clip.wav"
             concat_file = temp_path / "manifest.jsonl"
             write_wav(audio_path)
@@ -186,7 +186,7 @@ class ConcatCommandDryRunTests(unittest.TestCase):
         for manifest, expected_message in cases:
             with self.subTest(expected_message=expected_message):
                 with tempfile.TemporaryDirectory() as temp_dir:
-                    temp_path = Path(temp_dir)
+                    temp_path = Path(temp_dir).resolve()
                     write_wav(temp_path / "clip.wav")
                     concat_file = temp_path / "manifest.jsonl"
                     concat_file.write_text("\n" + manifest, encoding="utf-8")
@@ -209,7 +209,7 @@ class ConcatCommandDryRunTests(unittest.TestCase):
 
     def test_concat_dry_run_resolves_command_paths_from_cwd_and_audio_from_concat_file_directory(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             cwd_path = temp_path / "cwd"
             concat_dir = temp_path / "manifests"
             assets_dir = concat_dir / "assets"
@@ -240,7 +240,7 @@ class ConcatCommandDryRunTests(unittest.TestCase):
 
     def test_concat_dry_run_rejects_non_wav_output_and_audio_extensions_case_insensitively(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             audio_path = temp_path / "clip.mp3"
             concat_file = temp_path / "manifest.jsonl"
             audio_path.write_bytes(b"not checked after extension failure")
@@ -284,7 +284,7 @@ class ConcatCommandDryRunTests(unittest.TestCase):
         for audio_name, audio_content, expected_exit_code, expected_message in cases:
             with self.subTest(expected_message=expected_message):
                 with tempfile.TemporaryDirectory() as temp_dir:
-                    temp_path = Path(temp_dir)
+                    temp_path = Path(temp_dir).resolve()
                     concat_file = temp_path / "manifest.jsonl"
                     if audio_content == "empty":
                         write_empty_wav(temp_path / audio_name)
@@ -309,7 +309,7 @@ class ConcatCommandDryRunTests(unittest.TestCase):
                 self.assertIn(expected_message, stderr)
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             concat_file = temp_path / "manifest.jsonl"
             write_wav(temp_path / "first.wav", frame_rate=24000)
             write_wav(temp_path / "second.wav", frame_rate=22050)
@@ -337,7 +337,7 @@ class ConcatCommandDryRunTests(unittest.TestCase):
 
     def test_concat_dry_run_rejects_empty_manifest(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             concat_file = temp_path / "manifest.jsonl"
             concat_file.write_text("\n \n", encoding="utf-8")
 
@@ -358,7 +358,7 @@ class ConcatCommandDryRunTests(unittest.TestCase):
 
     def test_concat_dry_run_rejects_output_path_conflicts(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             audio_path = temp_path / "clip.wav"
             concat_file = temp_path / "manifest.jsonl"
             blocked_parent = temp_path / "blocked"
@@ -410,7 +410,7 @@ class ConcatCommandDryRunTests(unittest.TestCase):
 
     def test_concat_dry_run_rejects_existing_output_unless_force_without_modifying_it(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             audio_path = temp_path / "clip.wav"
             concat_file = temp_path / "manifest.jsonl"
             output_path = temp_path / "out.wav"
@@ -451,7 +451,7 @@ class ConcatCommandDryRunTests(unittest.TestCase):
 
     def test_concat_generates_wav_with_manifest_order_and_silence(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             first_path = temp_path / "first.wav"
             second_path = temp_path / "second.wav"
             concat_file = temp_path / "manifest.jsonl"
@@ -485,7 +485,7 @@ class ConcatCommandDryRunTests(unittest.TestCase):
 
     def test_concat_execution_does_not_initialize_or_check_model_resources(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             audio_path = temp_path / "clip.wav"
             concat_file = temp_path / "manifest.jsonl"
             output_path = temp_path / "out.wav"
@@ -515,7 +515,7 @@ class ConcatCommandDryRunTests(unittest.TestCase):
 
     def test_concat_force_overwrites_existing_output_during_real_execution(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             audio_path = temp_path / "clip.wav"
             concat_file = temp_path / "manifest.jsonl"
             output_path = temp_path / "out.wav"
@@ -554,7 +554,7 @@ class ConcatCommandDryRunTests(unittest.TestCase):
 
     def test_concat_execution_failure_returns_code_4_and_removes_temporary_wav(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             audio_path = temp_path / "clip.wav"
             concat_file = temp_path / "manifest.jsonl"
             output_path = temp_path / "out.wav"
@@ -592,7 +592,7 @@ class ConcatCommandDryRunTests(unittest.TestCase):
 
     def test_concat_cleanup_failure_is_appended_without_overriding_primary_failure(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             audio_path = temp_path / "clip.wav"
             concat_file = temp_path / "manifest.jsonl"
             output_path = temp_path / "out.wav"

--- a/cli_tests/test_cli_v2_config.py
+++ b/cli_tests/test_cli_v2_config.py
@@ -128,7 +128,7 @@ class ConfigCommandTests(unittest.TestCase):
 
     def test_init_creates_persistent_config_and_default_model_directory_without_model_files(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            state = user_state_paths(Path(temp_dir))
+            state = user_state_paths(Path(temp_dir).resolve())
 
             with mock.patch.dict(os.environ, state["env"], clear=False):
                 exit_code, stdout, stderr = self.run_cli(["init"])
@@ -145,7 +145,7 @@ class ConfigCommandTests(unittest.TestCase):
 
     def test_init_with_model_dir_persists_the_requested_model_directory(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             state = user_state_paths(temp_path)
             model_dir = temp_path / "custom-models"
 
@@ -163,7 +163,7 @@ class ConfigCommandTests(unittest.TestCase):
 
     def test_config_path_prints_the_persistent_config_file_location(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            state = user_state_paths(Path(temp_dir))
+            state = user_state_paths(Path(temp_dir).resolve())
 
             with mock.patch.dict(os.environ, state["env"], clear=False):
                 exit_code, stdout, stderr = self.run_cli(["config", "path"])
@@ -174,7 +174,7 @@ class ConfigCommandTests(unittest.TestCase):
 
     def test_config_set_model_dir_persists_the_model_resource_directory(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             state = user_state_paths(temp_path)
             model_dir = temp_path / "persisted-models"
 
@@ -190,7 +190,7 @@ class ConfigCommandTests(unittest.TestCase):
 
     def test_config_set_runtime_preferences_persists_device_and_boolean_values(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            state = user_state_paths(Path(temp_dir))
+            state = user_state_paths(Path(temp_dir).resolve())
 
             with mock.patch.dict(os.environ, state["env"], clear=False):
                 first = self.run_cli(["config", "set", "default_device", "cuda:0"])
@@ -217,7 +217,7 @@ class ConfigCommandTests(unittest.TestCase):
 
     def test_config_set_boolean_preference_rejects_non_boolean_values(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            state = user_state_paths(Path(temp_dir))
+            state = user_state_paths(Path(temp_dir).resolve())
 
             with mock.patch.dict(os.environ, state["env"], clear=False):
                 exit_code, stdout, stderr = self.run_cli(["config", "set", "use_fp16", "yes"])
@@ -230,7 +230,7 @@ class ConfigCommandTests(unittest.TestCase):
 
     def test_config_get_prints_the_current_persistent_config(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             state = user_state_paths(temp_path)
             model_dir = temp_path / "models"
 
@@ -246,7 +246,7 @@ class ConfigCommandTests(unittest.TestCase):
 
     def test_check_uses_persisted_model_dir_when_command_line_and_environment_do_not_override_it(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             state = user_state_paths(temp_path)
             model_dir = temp_path / "persisted-models"
             make_model_dir(model_dir)
@@ -262,7 +262,7 @@ class ConfigCommandTests(unittest.TestCase):
 
     def test_check_model_dir_resolution_prioritizes_command_line_then_environment_then_config(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             state = user_state_paths(temp_path)
             cli_model_dir = temp_path / "cli-models"
             env_model_dir = temp_path / "env-models"
@@ -288,7 +288,7 @@ class ConfigCommandTests(unittest.TestCase):
 
     def test_check_initializes_default_state_and_checks_the_platform_default_model_dir(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            state = user_state_paths(Path(temp_dir))
+            state = user_state_paths(Path(temp_dir).resolve())
 
             with mock.patch.dict(os.environ, state["env"], clear=False):
                 with mock.patch.dict(os.environ, {"INDEXTTS2_MODEL_DIR": ""}, clear=False):
@@ -305,7 +305,7 @@ class ConfigCommandTests(unittest.TestCase):
 
     def test_check_with_command_model_dir_still_initializes_default_state_without_persisting_override(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             state = user_state_paths(temp_path)
             cli_model_dir = temp_path / "cli-models"
             make_model_dir(cli_model_dir)
@@ -324,7 +324,7 @@ class ConfigCommandTests(unittest.TestCase):
 
     def test_synth_uses_persisted_model_dir_and_runtime_preferences_by_default(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             state = user_state_paths(temp_path)
             model_dir = temp_path / "models"
             voice_path = temp_path / "voice.wav"
@@ -378,7 +378,7 @@ class ConfigCommandTests(unittest.TestCase):
 
     def test_batch_uses_persisted_model_dir_and_runtime_preferences_by_default(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             state = user_state_paths(temp_path)
             model_dir = temp_path / "models"
             voice_path = temp_path / "voice.wav"
@@ -427,7 +427,7 @@ class ConfigCommandTests(unittest.TestCase):
 
     def test_batch_command_line_can_disable_persisted_boolean_runtime_preferences_for_one_run(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             state = user_state_paths(temp_path)
             model_dir = temp_path / "models"
             voice_path = temp_path / "voice.wav"
@@ -478,7 +478,7 @@ class ConfigCommandTests(unittest.TestCase):
 
     def test_synth_command_line_overrides_do_not_rewrite_persistent_config(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             state = user_state_paths(temp_path)
             persisted_model_dir = temp_path / "persisted-models"
             cli_model_dir = temp_path / "cli-models"
@@ -538,7 +538,7 @@ class ConfigCommandTests(unittest.TestCase):
 
     def test_synth_command_line_can_disable_persisted_boolean_runtime_preferences_for_one_run(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+            temp_path = Path(temp_dir).resolve()
             state = user_state_paths(temp_path)
             model_dir = temp_path / "models"
             voice_path = temp_path / "voice.wav"


### PR DESCRIPTION
Everything platform-specific in this repo is currently unverified by CI. `pyproject.toml` carries three `sys_platform` markers — `triton-windows` gated to win32, and the `wetext` / `WeTextProcessing` split on linux — and `cli_tests` branches three ways on `sys.platform` for config and model-cache locations. CI only ever exercised the Linux side of any of it.

The `triton-windows` marker bug (#742, #749) was exactly this shape: a Windows-only resolution failure that no amount of green Linux CI could have caught.

## Two commits, in this order

**`5906643` fixes the tests first.** The CLI assertions compare a path the CLI printed against one built from `tempfile.TemporaryDirectory()`. Those agree on Linux and nowhere else. Running the non-GPU suite on macOS — the other side of the same `sys_platform != 'linux'` branch — gives 18 failures out of 153, all the same root cause:

```
AssertionError: 'model_dir = "/var/folders/.../models"'
  not found in 'model_dir = "/private/var/folders/.../models"'
```

`/var` is a symlink to `/private/var` and the CLI resolves it. Windows has its own version — `RUNNER~1` 8.3 short names, drive-letter case — so this would have blocked a Windows job regardless of how the workflow was written.

The fix resolves at the point the temp directory is wrapped, which is what `cli_tests/test_cli_v2_download.py` already does at its seven sites, and why that file was the only one passing. 129 call sites across the other four files, no behaviour change: both sides of each comparison now use the same canonical form. **153 passed, 0 failed** afterwards.

**`2b47a3b` then adds the runner**, as a blocking check rather than advisory, since the failures it would have hit are gone.

## No GPU required

`-m "not gpu"` deselects the 22 GPU-marked tests. The one remaining case that passes `--device cuda` runs against a hand-built `SimpleNamespace` whose `is_available` is `lambda: True` (`cli_tests/test_cli_v2_check.py:93-98`), so nothing reaches for a real device.

## Workflow details

`fail-fast: false`, so a Windows failure still lets the Linux result through instead of masking it. `enable-cache: true` on `setup-uv` — the Windows job resolves a cu128 torch, and there is no reason to refetch that every run. Current Linux runs take ~1.4 min; Windows will be slower on first run and should settle once the cache warms.

## What this does not cover

Still Linux/Windows only. macOS would exercise the same non-Linux dependency branch as Windows and is where the path bug above was found, but it is not added here — worth considering separately if the cost is acceptable.