### PR TITLE
fix: drop the non-functional use_gpt_latent option from IndexTTS-2.5

### DIFF
--- a/indextts/infer_v2_5.py
+++ b/indextts/infer_v2_5.py
@@ -75,7 +75,7 @@ def apply_pronunciation_annotations(text: str) -> str:
 class IndexTTS2:
     def __init__(
             self, cfg_path="checkpoints/config.yaml", model_dir="checkpoints", use_bf16=False, device=None,
-            use_gpt_latent=False, use_cuda_kernel=None,use_deepspeed=False, use_accel=False, use_torch_compile=False, use_qwen_emo=False
+            use_cuda_kernel=None,use_deepspeed=False, use_accel=False, use_torch_compile=False, use_qwen_emo=False
     ):
         """
         Args:
@@ -186,9 +186,8 @@ class IndexTTS2:
         self.semantic_codec = self.semantic_codec.to(self.device)
         print('>> semantic_codec weights restored cost: ', time.perf_counter() - start_time)
 
-        self.use_gpt_latent = use_gpt_latent
         s2mel_path = os.path.join(self.model_dir, self.cfg.s2mel_checkpoint)
-        s2mel = MyModel(self.cfg.s2mel, use_gpt_latent=use_gpt_latent)
+        s2mel = MyModel(self.cfg.s2mel)
         s2mel, _, _, _ = load_checkpoint2(
             s2mel,
             None,
@@ -742,7 +741,6 @@ class IndexTTS2:
 
         wavs = []
         gpt_gen_time = 0
-        gpt_forward_time = 0
         s2mel_time = 0
         bigvgan_time = 0
         has_warned = False
@@ -825,33 +823,12 @@ class IndexTTS2:
                     print(f"fix codes shape: {codes.shape}, codes type: {codes.dtype}")
                     print(f"code len: {code_lens}")
 
-                m_start_time = time.perf_counter()
-                use_speed = torch.zeros(spk_cond_emb.size(0)).to(spk_cond_emb.device).long()
-                if self.use_gpt_latent:
-                    with torch.amp.autocast(text_tokens.device.type, enabled=self.dtype is not None, dtype=self.dtype):
-                        latent = self.gpt(
-                            speech_conditioning_latent,
-                            text_tokens,
-                            torch.tensor([text_tokens.shape[-1]], device=text_tokens.device),
-                            codes,
-                            torch.tensor([codes.shape[-1]], device=text_tokens.device),
-                            emo_cond_emb,
-                            cond_mel_lengths=torch.tensor([spk_cond_emb.shape[-1]], device=text_tokens.device),
-                            emo_cond_mel_lengths=torch.tensor([emo_cond_emb.shape[-1]], device=text_tokens.device),
-                            emo_vec=emovec,
-                            use_speed=use_speed,
-                        )
-                        gpt_forward_time += time.perf_counter() - m_start_time
-
                 dtype = None
                 with torch.amp.autocast(text_tokens.device.type, enabled=dtype is not None, dtype=dtype):
                     m_start_time = time.perf_counter()
                     diffusion_steps = 25
                     inference_cfg_rate = 0.7
                     S_infer = self.semantic_codec.decode(codes)
-                    if self.use_gpt_latent:
-                        latent = self.s2mel.models['gpt_layer'](latent)
-                        S_infer = S_infer + latent
                     target_lengths = torch.LongTensor([int(S_infer.shape[1] * 1.72 * duration_factor)]).to(codes.device)
 
                     cond = self.s2mel.models['length_regulator'](S_infer,
@@ -891,7 +868,6 @@ class IndexTTS2:
         wav = torch.cat(wavs, dim=1)
         wav_length = wav.shape[-1] / sampling_rate
         print(f">> gpt_gen_time: {gpt_gen_time:.2f} seconds")
-        print(f">> gpt_forward_time: {gpt_forward_time:.2f} seconds")
         print(f">> s2mel_time: {s2mel_time:.2f} seconds")
         print(f">> bigvgan_time: {bigvgan_time:.2f} seconds")
         print(f">> Total inference time: {end_time - start_time:.2f} seconds")


### PR DESCRIPTION
`IndexTTS2` in the 2.5 path accepts `use_gpt_latent`, but enabling it has never worked. As reported in #765:

```
RuntimeError: The size of tensor a (1706) must match the size of tensor b (853)
```

## Why the lengths can never agree

The two tensors are on different time bases by construction. `EnhancedCodec.decode()` upsamples by 2x — `indextts/codec/models.py:226`:

```python
x = F.interpolate(x, scale_factor=2, mode="nearest")
x_rec = self.up(x).transpose(1, 2)
```

`downsample_scale=2` is the constructor default and the released `config.yaml` does not override it, so that branch always runs. The `self.up` conv is `stride=1, padding=1`, so it preserves length — the total ratio is exactly 2x. The GPT latent stays at the code-token rate. 853 → 1706 is precisely that factor.

**This is 2.5-specific.** 2.0 hardcodes `use_gpt_latent=True` (`indextts/infer_v2.py:145`) and works fine, because it uses the maskgct codec, which has no such upsampling step. When 2.5 switched to `EnhancedCodec`, the latent path was left wired to the old assumption.

## Why remove rather than align

#765 proposes aligning with `nearest` interpolation to match the codec's own expansion. That is a reasonable guess, and it does make the path execute — but it is a guess. Nothing in the tree records how the GPT latent was aligned with semantic features during training, so the alignment would be inferred rather than recovered. If it is wrong the result is quietly degraded audio rather than a crash, which is harder to notice than the current error.

The released 2.5 checkpoint does contain six `gpt_layer` tensors, which #765 cites as evidence the path is intended. That only records what the training run constructed, not that this is a supported inference path — and if 2.5 had actually been trained through this fusion, the lengths would agree. They do not.

So this removes the option from 2.5 instead of guessing at it. If the path is wanted later, it should come back with the alignment taken from the training recipe.

## Blast radius: none

- The parameter defaulted to `False`.
- Neither `webui.py` nor `indextts/cli_v2.py` exposes it — only code constructing `IndexTTS2(...)` directly could reach it, and only to crash.
- `load_checkpoint2` iterates `for key in model.models`, so the now-unbuilt `gpt_layer` weights are skipped silently, no warning.
- `MyModel` keeps its `use_gpt_latent` argument, which `backends/trt/export/*.py` still passes — untouched.

Also drops the `gpt_forward_time` counter, whose only accumulation site was inside the removed block. It would otherwise print a constant `0.00`, reading as "this stage was free" rather than "this stage does not exist". 2.0 keeps its own counter.

## Verification

- `uv run --extra test pytest -m "not gpu"` → **153 passed, 22 deselected**
- A real inference on the default path still produces audio, with the removed timing line gone from the output.

Closes #765 as an alternative, if maintainers agree the path should be dropped rather than approximated.