### PR TITLE
fix: forward do_sample to inference_speech in both v2 and v2.5

### DIFF
--- a/indextts/infer_v2.py
+++ b/indextts/infer_v2.py
@@ -586,7 +586,7 @@ class IndexTTS2:
                         cond_lengths=torch.tensor([spk_cond_emb.shape[-1]], device=text_tokens.device),
                         emo_cond_lengths=torch.tensor([emo_cond_emb.shape[-1]], device=text_tokens.device),
                         emo_vec=emovec,
-                        do_sample=True,
+                        do_sample=do_sample,
                         top_p=top_p,
                         top_k=top_k,
                         temperature=temperature,

--- a/indextts/infer_v2_5.py
+++ b/indextts/infer_v2_5.py
@@ -777,7 +777,7 @@ class IndexTTS2:
                         emo_vec=emovec,
                         campplus_embedding=style,
                         wav=spk_audio_prompt,
-                        do_sample=True,
+                        do_sample=do_sample,
                         top_p=top_p,
                         top_k=top_k,
                         temperature=temperature,


### PR DESCRIPTION
`infer_generator()` parses `do_sample` out of `generation_kwargs` and then never uses it — the call to `inference_speech()` passes a literal `True`:

| file | parsed | passed |
| --- | --- | --- |
| `indextts/infer_v2.py` | `:536` `do_sample = generation_kwargs.pop("do_sample", True)` | `:589` `do_sample=True,` |
| `indextts/infer_v2_5.py` | `:731` same | `:780` `do_sample=True,` |

In both files the parsed local is dead — those two lines are its only mentions. And because the value is `pop`ped rather than left in `generation_kwargs`, an explicit `do_sample=False` is swallowed silently instead of reaching the model. Greedy decoding has therefore never been reachable through the public `infer()` API.

The value does have somewhere to arrive: `inference_speech()` collects `**hf_generate_kwargs` and forwards them into `GPT2InferenceModel.generate()` (`indextts/gpt/model_v2.py:820`, `indextts/gpt/model_v2_5.py:779`), which is where HuggingFace reads `do_sample`. So this is a two-character fix per file, not a missing feature.

Default behaviour is unchanged: the `pop` default is still `True`, and only an explicit `do_sample=False` now takes effect.

## Relation to #726

#726 reported this and fixed the `infer_v2.py` site. It has now been closed in favour of this PR, which applies the same one-line change to `infer_v2_5.py` as well — that file has the identical defect and is the current default path, so a v2-only fix would have left the bug in place for most users. Credit for the diagnosis goes to @John6666cat.

Fixes #577.

## Verification

`uv run --extra test pytest -m "not gpu"` → 151 passed. Two `test_model_download_reachable` cases fail on HuggingFace CDN SSL resets (`SSL: UNEXPECTED_EOF_WHILE_READING` from `us.aws.cdn.hf.co`); those reproduce on unmodified `main`, so they are unrelated to this change.
