### PR TITLE
feat: add --share argument for Gradio WebUI

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -33,6 +33,8 @@ parser.add_argument("--accel", action="store_true", default=False, help="Use GPT
 parser.add_argument("--torch_compile", action="store_true", default=False, help="Use torch.compile to optimize s2mel if available")
 parser.add_argument("--qwen_emo", action="store_true", default=False, help="Load QwenEmotion even on a low-VRAM GPU, where it is skipped by default")
 parser.add_argument("--gui_seg_tokens", type=int, default=120, help="GUI: Max tokens per generation segment")
+parser.add_argument("--share", action="store_true", default=False, help="Enable the sharing mode of Gradio WebUI for easier use on platforms such as Colab.")
+
 cmd_args = parser.parse_args()
 
 # Validate optional acceleration dependencies early, so missing extras fail
@@ -1357,4 +1359,4 @@ with gr.Blocks(
 
 if __name__ == "__main__":
     demo.queue(20)
-    demo.launch(server_name=cmd_args.host, server_port=cmd_args.port)
+    demo.launch(server_name=cmd_args.host, server_port=cmd_args.port,share=cmd_args.share)


### PR DESCRIPTION
## Description

This PR adds a `--share` argument for the Gradio WebUI in `argparse` and passes it to `demo.launch()`. 

**Why:** Many users run this project on headless cloud platforms (like Google Colab, Kaggle, or remote servers). By adding this argument, users can easily generate a public Gradio share link simply by appending `--share` in the command line, avoiding the need to manually edit the code.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation / comments only
- [ ] Build / CI / dependency change
- [ ] Refactor (no behaviour change)

## How has this been tested?

Manually tested launching the web UI with the `--share` flag to verify the public link generation. Also ran the local test suite to ensure nothing is broken.

```bash
uv run pytest -m "not gpu"
```

## Checklist

- [x] Tests pass locally: `uv run pytest -m "not gpu"` (no GPU) or `uv run pytest tests/test_v2.py` (with GPU)
- [ ] I have added or updated tests to cover my changes (where applicable). *(N/A for a simple CLI argument)*
- [ ] I have added or updated docstrings for any changed public functions. *(N/A)*

## Screenshots / output (if relevant)

```bash
# Output when running with --share
Running on local URL:  http://127.0.0.1:7860
Running on public URL: https://xxxxxxxxxxxx.gradio.live

This share link expires in 72 hours.
```

