### PR TITLE
fix: avoid synthetic TTS prompt KV-cache hits

### DIFF
--- a/indextts/accel/accel_engine.py
+++ b/indextts/accel/accel_engine.py
@@ -458,6 +458,10 @@ class AccelInferenceEngine:
             self.kv_manager.allocate(req)
             sequences.append(req)
 
+        if tts_embeddings is not None:
+            for seq in sequences:
+                seq.num_cached_tokens = 0
+
         self.current_sequences = sequences
 
         prefill_ids, prefill_pos = self._prepare_prefill(sequences)


### PR DESCRIPTION
## Summary

When the GPT acceleration path is enabled, TTS prompts are represented by synthetic token IDs (`[1, 1, ...]`) while the model consumes the actual prompt embeddings. A previous request can therefore make `KVCacheManager.allocate()` report a full cached block for a later TTS prompt even though those embeddings are different. During prefill, the KV cache writer then receives fewer slot mappings than key/value rows and raises an assertion.

For TTS embedding prompts, reset `Seq.num_cached_tokens` after allocation so the full prompt is prefetched and written to the cache. This keeps `slot_mapping` aligned with the actual embedding sequence length. Short prompts are unaffected; the reset matters when a prompt spans a complete cache block and would otherwise hit the synthetic-token cache.

The same acceleration engine is used by both `model_v2.py` (IndexTTS 2.0) and `model_v2_5.py` (IndexTTS 2.5), so this fix applies to both versions when `use_accel=True`.

## Reproduction

With the upstream parameter `max_text_tokens_per_segment=220` (named `max_tokens` by the index-server wrapper), this input is split by the v2 tokenizer into segments of 219 and 18 tokens:

```text
三人飞奔在丛林之中，沿途也是遇见了yi4些不少游荡在这些地方准备抢夺身份牌的参赛者，bu2过每当yi4些家huo5想要蠢蠢欲动时，一支箭矢便是会陡然撕裂空气，狠狠的射在他们脚下的地面上，那剧烈摆动的箭尾，让得他们明bai5，若是让这木箭射到身体上的话，必然会是yi2个血洞。
```

The first segment produces exactly 256 prompt rows: 32 speaker-conditioning latents + 2 duration latents + 219 text tokens + 2 text boundary tokens + 1 start-mel token. A repeated synthetic-token prompt therefore reuses one complete 256-slot block and leaves zero slot mappings for 256 key/value rows without this fix.

## Hardware and parameter context

The failure was reproduced on an NVIDIA RTX5880-Ada-48Q with 48 GiB VRAM (driver 570.172.18, CUDA 12.8, PyTorch 2.8.0+cu128). `max_text_tokens_per_segment` is an existing upstream inference parameter, not a new API introduced by this change. Its default of 120 can split longer Chinese sentences into unnecessarily short segments; on this GPU, using 220 is a reasonable setting that keeps more context per segment. The fix makes that existing tuning parameter safe to use with the acceleration engine.

## Crash report

```text
INFO:     127.0.0.1:54502 - "POST /tts HTTP/1.1" 500 Internal Server Error
>> starting inference...
Use the specified emotion vector
ERROR:root:TTS error: Traceback (most recent call last):
  File "/home/wangke/index-server/src/index_server/app.py", line 1622, in _text_to_speech_local_response
    sr, wav_data = await _run_tts_inference(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/src/index_server/app.py", line 1017, in _run_tts_inference
    return await run_backend()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/src/index_server/app.py", line 980, in run_backend
    result = await asyncio.to_thread(
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/.local/share/uv/python/cpython-3.11-linux-x86_64-gnu/lib/python3.11/asyncio/threads.py", line 25, in to_thread
    return await loop.run_in_executor(None, func_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/.local/share/uv/python/cpython-3.11-linux-x86_64-gnu/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/src/index_server/backends/indextts2.py", line 63, in infer_sync
    return model.infer(
           ^^^^^^^^^^^^
  File "/home/wangke/index-server/vendor/index-tts/indextts/infer_v2.py", line 395, in infer
    return list(self.infer_generator(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/vendor/index-tts/indextts/infer_v2.py", line 594, in infer_generator
    codes, speech_conditioning_latent = self.gpt.inference_speech(
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/vendor/index-tts/indextts/gpt/model_v2.py", line 804, in inference_speech
    output = self.accel_engine.generate(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/vendor/index-tts/indextts/accel/accel_engine.py", line 506, in generate
    hidden_states = self.model(
                    ^^^^^^^^^^^
  File "/home/wangke/index-server/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/vendor/index-tts/indextts/accel/gpt2_accel.py", line 154, in forward
    hidden_states = block(hidden_states)[0]
                    ^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/.venv/lib/python3.11/site-packages/transformers/utils/deprecation.py", line 172, in wrapped_func
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/.venv/lib/python3.11/site-packages/transformers/models/gpt2/modeling_gpt2.py", line 403, in forward
    attn_output, self_attn_weights = self.attn(
                                     ^^^^^^^^^^
  File "/home/wangke/index-server/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1784, in _wrapped_call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/vendor/index-tts/indextts/accel/gpt2_accel.py", line 88, in forward
    o_flat = self.accel_attn(q_flat, k_flat, v_flat)  # [B*T, H, D]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1784, in _wrapped_call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangke/index-server/vendor/index-tts/indextts/accel/attention.py", line 127, in forward
    store_kvcache(k, v, k_cache, v_cache, context.slot_mapping)
  File "/home/wangke/index-server/vendor/index-tts/indextts/accel/attention.py", line 101, in store_kvcache
    assert slot_mapping.numel() == N
           ^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

## Verification

- `python -m py_compile indextts/accel/accel_engine.py`
- Reproduced the mismatch in the cache manager with a repeated 300-token synthetic prompt: 256 cached tokens produced 44 slot mappings for 300 key/value rows; resetting the cache marker produces 300 mappings.
- A full model inference test requires the project checkpoints and CUDA runtime.
