### PR TITLE
fix: select Ascend NPU instead of falling back to CPU in infer_v2

### DIFF
--- a/indextts/infer_v2.py
+++ b/indextts/infer_v2.py
@@ -32,6 +32,52 @@ import safetensors
 import random
 import torch.nn.functional as F
 
+
+def _is_npu_available():
+    """Whether an Ascend NPU is usable through the ``torch_npu`` extension.
+
+    ``torch.npu`` is only registered as a side effect of importing ``torch_npu``,
+    so the extension has to be imported before its availability can be probed.
+    On machines without ``torch_npu`` installed this is a cheap no-op.
+
+    Returns:
+        bool: True if ``torch_npu`` is importable and reports an available NPU.
+    """
+    try:
+        import torch_npu  # noqa: F401
+    except (ImportError, OSError):
+        # Either not installed, or installed without a working CANN runtime.
+        return False
+    return hasattr(torch, "npu") and torch.npu.is_available()
+
+
+def _autodetect_device(use_fp16, use_cuda_kernel):
+    """Pick the best available device, along with the flags that suit it.
+
+    Priority order is CUDA, Ascend NPU, XPU, MPS and finally CPU. Only CUDA can
+    use the fused BigVGAN kernel, and MPS is faster in float32 than float16.
+
+    Args:
+        use_fp16 (bool): fp16 preference requested by the caller.
+        use_cuda_kernel (None | bool): BigVGAN CUDA kernel preference, where
+            None means "enable it when the device supports it".
+
+    Returns:
+        tuple[str, bool, bool]: the device, and the resolved
+            ``use_fp16`` / ``use_cuda_kernel`` flags for it.
+    """
+    if torch.cuda.is_available():
+        return "cuda:0", use_fp16, use_cuda_kernel is None or use_cuda_kernel
+    if _is_npu_available():
+        return "npu:0", use_fp16, False
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        return "xpu", use_fp16, False
+    if hasattr(torch, "mps") and torch.backends.mps.is_available():
+        return "mps", False, False  # Use float16 on MPS is overhead than float32
+    print(">> Be patient, it may take a while to run in CPU mode.")
+    return "cpu", False, False
+
+
 class IndexTTS2:
     def __init__(
             self, cfg_path="checkpoints/config.yaml", model_dir="checkpoints", use_fp16=False, device=None,
@@ -43,7 +89,8 @@ class IndexTTS2:
             cfg_path (str): path to the config file.
             model_dir (str): path to the model directory.
             use_fp16 (bool): whether to use fp16.
-            device (str): device to use (e.g., 'cuda:0', 'cpu'). If None, it will be set automatically based on the availability of CUDA or MPS.
+            device (str): device to use (e.g., 'cuda:0', 'npu:0', 'cpu'). If None, it will be set automatically
+                based on the availability of CUDA, Ascend NPU, XPU or MPS.
             use_cuda_kernel (None | bool): whether to use BigVGan custom fused activation CUDA kernel, only for CUDA device.
             use_deepspeed (bool): whether to use DeepSpeed or not.
             use_accel (bool): whether to use acceleration engine for GPT2 or not.
@@ -63,23 +110,8 @@ class IndexTTS2:
             self.device = device
             self.use_fp16 = False if device == "cpu" else use_fp16
             self.use_cuda_kernel = use_cuda_kernel is not None and use_cuda_kernel and device.startswith("cuda")
-        elif torch.cuda.is_available():
-            self.device = "cuda:0"
-            self.use_fp16 = use_fp16
-            self.use_cuda_kernel = use_cuda_kernel is None or use_cuda_kernel
-        elif hasattr(torch, "xpu") and torch.xpu.is_available():
-            self.device = "xpu"
-            self.use_fp16 = use_fp16
-            self.use_cuda_kernel = False
-        elif hasattr(torch, "mps") and torch.backends.mps.is_available():
-            self.device = "mps"
-            self.use_fp16 = False  # Use float16 on MPS is overhead than float32
-            self.use_cuda_kernel = False
         else:
-            self.device = "cpu"
-            self.use_fp16 = False
-            self.use_cuda_kernel = False
-            print(">> Be patient, it may take a while to run in CPU mode.")
+            self.device, self.use_fp16, self.use_cuda_kernel = _autodetect_device(use_fp16, use_cuda_kernel)
 
         self.cfg = OmegaConf.load(cfg_path)
         self.model_dir = model_dir

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -7,6 +7,7 @@ Run with:
 CI only (no GPU):
     uv run --extra test pytest tests/test_v2.py -v -m "not gpu"
 """
+import builtins
 import importlib
 import sys
 import types
@@ -384,6 +385,127 @@ def test_qwen_emotion_convert_redirects_cross_key_labels(module_name, monkeypatc
     emotion_dict = emo.convert({"高兴": "自然"})
     assert emotion_dict["happy"] == 0.0
     assert emotion_dict["calm"] == 1.0
+
+
+# -- Device auto-detection (no GPU) -------------------------------------------
+
+def _fake_torch(cuda=False, xpu=False, mps=False, npu=None):
+    """Build a stand-in for the ``torch`` module exposing only device probes.
+
+    ``npu=None`` models a machine where ``torch_npu`` never registered
+    ``torch.npu``; True/False model an Ascend backend that is present and
+    reports itself as available or not.
+    """
+    fake = types.SimpleNamespace(
+        cuda=types.SimpleNamespace(is_available=lambda: cuda),
+        xpu=types.SimpleNamespace(is_available=lambda: xpu),
+        # torch.mps exists on any modern build; torch.backends.mps.is_available()
+        # is what actually reports usable Apple silicon.
+        mps=types.SimpleNamespace(is_available=lambda: mps),
+        backends=types.SimpleNamespace(mps=types.SimpleNamespace(is_available=lambda: mps)),
+    )
+    if npu is not None:
+        fake.npu = types.SimpleNamespace(is_available=lambda: npu)
+    return fake
+
+
+def _install_torch_npu(monkeypatch, module=None):
+    """Pretend the ``torch_npu`` extension is installed and importable."""
+    monkeypatch.setitem(sys.modules, "torch_npu", module or types.ModuleType("torch_npu"))
+
+
+def test_autodetect_selects_npu_when_only_ascend_is_available(monkeypatch):
+    """An Ascend NPU host must not silently fall back to CPU (issue #712)."""
+    module = _load_qwen_emotion_module("indextts.infer_v2", monkeypatch)
+    _install_torch_npu(monkeypatch)
+    monkeypatch.setattr(module, "torch", _fake_torch(npu=True))
+
+    device, use_fp16, use_cuda_kernel = module._autodetect_device(use_fp16=True, use_cuda_kernel=None)
+
+    assert device == "npu:0"
+    assert use_fp16 is True
+    # The fused BigVGAN kernel is CUDA-only.
+    assert use_cuda_kernel is False
+
+
+def test_autodetect_prefers_cuda_over_npu(monkeypatch):
+    module = _load_qwen_emotion_module("indextts.infer_v2", monkeypatch)
+    _install_torch_npu(monkeypatch)
+    monkeypatch.setattr(module, "torch", _fake_torch(cuda=True, npu=True))
+
+    device, _, use_cuda_kernel = module._autodetect_device(use_fp16=True, use_cuda_kernel=None)
+
+    assert device == "cuda:0"
+    assert use_cuda_kernel is True
+
+
+def test_autodetect_prefers_npu_over_xpu_and_mps(monkeypatch):
+    module = _load_qwen_emotion_module("indextts.infer_v2", monkeypatch)
+    _install_torch_npu(monkeypatch)
+    monkeypatch.setattr(module, "torch", _fake_torch(npu=True, xpu=True, mps=True))
+
+    device, _, _ = module._autodetect_device(use_fp16=True, use_cuda_kernel=None)
+
+    assert device == "npu:0"
+
+
+@pytest.mark.parametrize(
+    "torch_npu_installed,npu,expected",
+    [
+        (False, None, False),  # torch_npu not installed at all
+        (True, None, False),   # imported, but torch.npu never registered
+        (True, False, False),  # extension present, no usable NPU device
+        (True, True, True),    # Ascend NPU present and usable
+    ],
+)
+def test_is_npu_available(torch_npu_installed, npu, expected, monkeypatch):
+    module = _load_qwen_emotion_module("indextts.infer_v2", monkeypatch)
+    if torch_npu_installed:
+        _install_torch_npu(monkeypatch)
+    else:
+        monkeypatch.delitem(sys.modules, "torch_npu", raising=False)
+    monkeypatch.setattr(module, "torch", _fake_torch(npu=npu))
+
+    assert module._is_npu_available() is expected
+
+
+def test_is_npu_available_survives_broken_cann_runtime(monkeypatch):
+    """A torch_npu install without a working CANN runtime must not crash startup."""
+    module = _load_qwen_emotion_module("indextts.infer_v2", monkeypatch)
+    monkeypatch.delitem(sys.modules, "torch_npu", raising=False)
+    monkeypatch.setattr(module, "torch", _fake_torch(npu=True))
+
+    real_import = builtins.__import__
+
+    def failing_import(name, *args, **kwargs):
+        if name == "torch_npu":
+            raise OSError("libascendcl.so: cannot open shared object file")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", failing_import)
+
+    assert module._is_npu_available() is False
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected_device,expected_fp16",
+    [
+        ({"cuda": True}, "cuda:0", True),
+        ({"xpu": True}, "xpu", True),
+        ({"mps": True}, "mps", False),
+        ({}, "cpu", False),
+    ],
+)
+def test_autodetect_preserves_existing_backend_order(kwargs, expected_device, expected_fp16, monkeypatch):
+    """Adding NPU must not change how the pre-existing backends are picked."""
+    module = _load_qwen_emotion_module("indextts.infer_v2", monkeypatch)
+    monkeypatch.delitem(sys.modules, "torch_npu", raising=False)
+    monkeypatch.setattr(module, "torch", _fake_torch(**kwargs))
+
+    device, use_fp16, _ = module._autodetect_device(use_fp16=True, use_cuda_kernel=None)
+
+    assert device == expected_device
+    assert use_fp16 is expected_fp16
 
 
 # -- Inference (GPU required) --------------------------------------------------


### PR DESCRIPTION
## Description

Fixes #712.

`IndexTTS2` autodetection in `indextts/infer_v2.py` probed CUDA, then XPU, then MPS, and otherwise fell through to CPU. There was no Ascend NPU branch, so a host with Ascend NPUs and `torch_npu` installed silently ran inference on CPU.

### Root cause

The cascade had no NPU check at all. An XPU-style one-liner would not have been enough either, because `torch.npu` is only registered **as a side effect of importing `torch_npu`**, so `hasattr(torch, "npu")` is `False` until that import has happened:

```python
elif hasattr(torch, "xpu") and torch.xpu.is_available():   # works, torch.xpu is built in
...
# hasattr(torch, "npu") is False on an Ascend box until `import torch_npu` runs
```

### Fix

- New `_is_npu_available()` imports `torch_npu` first, then probes `torch.npu.is_available()`. A missing or unusable install (`ImportError` / `OSError`, e.g. `torch_npu` present without a working CANN runtime) is treated as *unavailable*, so this cannot break startup on non-Ascend platforms. This mirrors the detection `transformers` uses in `is_torch_npu_available()`.
- NPU is probed directly after CUDA, so the order is **CUDA → NPU → XPU → MPS → CPU**. The device is reported as `npu:0`, and the fused BigVGAN kernel stays disabled because it is CUDA-only.
- The cascade moved out of `__init__` into `_autodetect_device()`. This is the one non-obvious part of the diff and it is deliberate: it makes the priority order unit-testable without the corresponding hardware, which matters given the verification gap below. It follows the existing testable-seam style of `_detect_devices(torch_module)` in `indextts/cli_v2.py`. Behaviour is otherwise unchanged, including the `>> Be patient...` CPU notice.

`fp16` is kept enabled on NPU, following the XPU branch.

## ⚠️ Verification gap — please review carefully

**I do not have access to Ascend NPU hardware, so the NPU code path has never been executed.** This change is the result of code review against the `torch_npu` API rather than a live run. Specifically **unverified**:

- that `torch.npu.is_available()` returns `True` on a real Ascend host after `import torch_npu`,
- that `"npu:0"` is the right device string for the subsequent `.to(self.device)` calls,
- that inference actually completes end to end on an NPU, and that fp16 is a sensible default there.

What *is* verified is that the change is inert on non-NPU machines (see below), so the downside risk is limited to "NPU still doesn't work", not a regression for existing CUDA/XPU/MPS/CPU users.

**Could a maintainer or a contributor with an Ascend box please confirm the NPU path?** The useful check is that `IndexTTS2(...)` with no explicit `device=` reports `npu:0` rather than `cpu`, and that inference produces audio. I am happy to amend the PR based on what you find — including dropping fp16 on NPU or changing the device string.

## How has this been tested?

Full non-GPU suite, on a CPU-only Windows machine (no CUDA, no NPU):

```bash
uv run --extra test pytest -m "not gpu"
# 165 passed, 22 deselected, 30 subtests passed in 178.49s
```

New tests (12 cases) covering the selection logic with `torch` and `torch_npu` faked, so no accelerator is required:

```bash
uv run --extra test pytest tests/test_v2.py -k "npu or autodetect" -v
# 12 passed
```

- `test_autodetect_selects_npu_when_only_ascend_is_available` — the issue's scenario: NPU present, no CUDA → `npu:0`, not `cpu`.
- `test_autodetect_prefers_cuda_over_npu` / `test_autodetect_prefers_npu_over_xpu_and_mps` — priority order.
- `test_is_npu_available` (4 params) — not installed / imported but `torch.npu` never registered / present but no usable device / present and usable.
- `test_is_npu_available_survives_broken_cann_runtime` — `OSError` on import is swallowed.
- `test_autodetect_preserves_existing_backend_order` (4 params) — CUDA/XPU/MPS/CPU selection is unchanged by the refactor.

**Negative control:** with the `_is_npu_available()` branch disabled, `test_autodetect_selects_npu_when_only_ascend_is_available` and `test_autodetect_prefers_npu_over_xpu_and_mps` fail (`assert 'cpu' == 'npu:0'` and `assert 'xpu' == 'npu:0'`); they pass with it restored. So the tests genuinely exercise the new branch rather than passing incidentally.

**No-regression check against real `torch` 2.8.0** on this CPU-only box:

```
torch_npu installed: False
_is_npu_available() -> False
_autodetect_device(True, None) -> ('cpu', False, False)
```

i.e. unchanged CPU behaviour, and the new import probe fails safely when `torch_npu` is absent.

## Scope note

I kept the diff to the file named in the issue. The same missing-NPU-branch gap also exists in `indextts/infer.py`, `indextts/infer_v2_5.py`, `indextts/cli.py`, and in `_detect_devices` / `_device_family` in `indextts/cli_v2.py` (so `--device npu` is currently rejected by `indextts2 check`). I left those alone on purpose rather than widening an unverifiable change — `infer_v2_5.py` in particular uses `use_bf16`, and whether a given Ascend part supports bf16 is exactly the sort of thing I cannot confirm without hardware. Happy to extend this PR to any or all of them if you'd prefer it in one go.

Separately, `torch.cuda.empty_cache()` at two points in `infer_v2.py` is unconditional. It is a harmless no-op when CUDA was never initialised, so it does not break NPU runs, but it also won't release NPU memory. Left as-is to keep this diff focused; worth a follow-up if NPU support lands.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation / comments only
- [ ] Build / CI / dependency change
- [ ] Refactor (no behaviour change)

## Checklist

- [x] Tests pass locally: `uv run pytest -m "not gpu"` (no GPU)
- [x] I have added or updated tests to cover my changes (where applicable).
- [x] I have added or updated docstrings for any changed public functions.
