### PR TITLE
fix: normalize waveforms before torchaudio.save to avoid saturated WAVs on torchaudio 2.9+

### DIFF
--- a/backends/trt/infer.py
+++ b/backends/trt/infer.py
@@ -28,7 +28,8 @@ import time
 
 import numpy as np
 import torch
-import torchaudio
+
+from indextts.utils.common import save_pcm_wav
 
 
 def main():
@@ -182,8 +183,8 @@ def main():
         print(f"  Total time:        {elapsed:.2f}s")
         print(f"  RTF:               {elapsed / duration:.4f}")
 
-        wav = torch.tensor(full_audio, dtype=torch.float32).unsqueeze(0).to(torch.int16)
-        torchaudio.save(outputs[0], wav, sr)
+        wav = torch.tensor(full_audio, dtype=torch.float32).unsqueeze(0)
+        save_pcm_wav(outputs[0], wav, sr)
         print(f"  Saved: {outputs[0]}")
 
     elif is_batch and args.stream:
@@ -230,8 +231,8 @@ def main():
                 total_duration += duration
                 out_path = outputs[b] if b < len(outputs) else outputs[0].replace(".wav", f"_{b}.wav")
                 os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
-                wav = torch.tensor(full_audio, dtype=torch.float32).unsqueeze(0).to(torch.int16)
-                torchaudio.save(out_path, wav, sr)
+                wav = torch.tensor(full_audio, dtype=torch.float32).unsqueeze(0)
+                save_pcm_wav(out_path, wav, sr)
                 print(f"  [{b}] {duration:.2f}s -> {out_path}")
 
         print(f"\n  Total audio:       {total_duration:.2f}s")
@@ -261,8 +262,8 @@ def main():
             total_duration += duration
             out_path = outputs[i] if i < len(outputs) else outputs[0].replace(".wav", f"_{i}.wav")
             os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
-            wav = torch.tensor(audio.T, dtype=torch.int16)
-            torchaudio.save(out_path, wav, sr)
+            wav = torch.tensor(audio.T, dtype=torch.float32)
+            save_pcm_wav(out_path, wav, sr)
             print(f"  [{i}] {duration:.2f}s -> {out_path}")
 
         print(f"\n  Total audio:  {total_duration:.2f}s")

--- a/backends/trt/pipeline/pipeline.py
+++ b/backends/trt/pipeline/pipeline.py
@@ -8,8 +8,9 @@ from typing import Generator, List, Optional, Tuple, Union
 import numpy as np
 import torch
 import torch.nn.functional as F
-import torchaudio
 from transformers import SeamlessM4TFeatureExtractor
+
+from indextts.utils.common import save_pcm_wav
 
 from backends.trt.pipeline.config import TTSConfig, load_config
 from backends.trt.pipeline.text_processing import TextNormalizer, TextTokenizer
@@ -1011,5 +1012,5 @@ class FasterIndexTTS2:
         if os.path.isfile(path):
             os.remove(path)
         os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-        torchaudio.save(path, wav.cpu().to(torch.int16), SAMPLE_RATE)
+        save_pcm_wav(path, wav, SAMPLE_RATE)
         print(f">> WAV saved to {path}")

--- a/indextts/infer.py
+++ b/indextts/infer.py
@@ -19,6 +19,7 @@ warnings.filterwarnings("ignore", category=UserWarning)
 from indextts.BigVGAN.models import BigVGAN as Generator
 from indextts.gpt.model import UnifiedVoice
 from indextts.utils.checkpoint import load_checkpoint
+from indextts.utils.common import save_pcm_wav
 from indextts.utils.feature_extractors import MelSpectrogramFeatures
 
 from indextts.utils.front import TextNormalizer, TextTokenizer
@@ -506,7 +507,7 @@ class IndexTTS:
         if output_path:
             # 直接保存音频到指定路径中
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
-            torchaudio.save(output_path, wav.type(torch.int16), sampling_rate)
+            save_pcm_wav(output_path, wav, sampling_rate)
             print(">> wav file saved to:", output_path)
             return output_path
         else:
@@ -673,7 +674,7 @@ class IndexTTS:
                 print(">> remove old wav file:", output_path)
             if os.path.dirname(output_path) != "":
                 os.makedirs(os.path.dirname(output_path), exist_ok=True)
-            torchaudio.save(output_path, wav.type(torch.int16), sampling_rate)
+            save_pcm_wav(output_path, wav, sampling_rate)
             print(">> wav file saved to:", output_path)
             return output_path
         else:

--- a/indextts/infer_v2.py
+++ b/indextts/infer_v2.py
@@ -19,6 +19,7 @@ from omegaconf import OmegaConf
 from indextts.gpt.model_v2 import UnifiedVoice
 from indextts.codec.maskgct_codec import build_semantic_codec
 from indextts.utils.checkpoint import load_checkpoint
+from indextts.utils.common import save_pcm_wav
 from indextts.utils.front import TextNormalizer, TextTokenizer
 
 from indextts.s2mel.modules.commons import load_checkpoint2, MyModel
@@ -712,7 +713,7 @@ class IndexTTS2:
                 print(">> remove old wav file:", output_path)
             if os.path.dirname(output_path) != "":
                 os.makedirs(os.path.dirname(output_path), exist_ok=True)
-            torchaudio.save(output_path, wav.type(torch.int16), sampling_rate)
+            save_pcm_wav(output_path, wav, sampling_rate)
             print(">> wav file saved to:", output_path)
             if stream_return:
                 return None

--- a/indextts/infer_v2_5.py
+++ b/indextts/infer_v2_5.py
@@ -20,6 +20,7 @@ from omegaconf import OmegaConf
 from indextts.codec.models import EnhancedCodec
 from indextts.gpt.model_v2 import UnifiedVoice
 from indextts.utils.checkpoint import load_checkpoint
+from indextts.utils.common import save_pcm_wav
 from indextts.utils.front import TextNormalizer
 from indextts.utils.tokenizer import get_tokenizer, lang_to_token
 from indextts.utils.ja_g2p import JapaneseG2PProcessor
@@ -538,7 +539,7 @@ class IndexTTS2:
                         os.remove(output_path)
                     if os.path.dirname(output_path) != "":
                         os.makedirs(os.path.dirname(output_path), exist_ok=True)
-                    torchaudio.save(output_path, wav, sampling_rate)
+                    save_pcm_wav(output_path, wav, sampling_rate)
                     print(">> wav file saved to:", output_path)
                     return output_path
                 else:
@@ -884,7 +885,7 @@ class IndexTTS2:
             if os.path.dirname(output_path) != "":
                 os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
-            torchaudio.save(output_path, wav.type(torch.int16), sampling_rate)
+            save_pcm_wav(output_path, wav, sampling_rate)
             print(">> wav file saved to:", output_path)
             if stream_return:
                 return None

--- a/indextts/utils/common.py
+++ b/indextts/utils/common.py
@@ -7,6 +7,56 @@ import torchaudio
 
 MATPLOTLIB_FLAG = False
 
+# Full-scale value used everywhere we convert between normalized waveforms and
+# 16-bit PCM. 32767 rather than 32768 so that the positive peak cannot overflow.
+PCM16_MAX = 32767.0
+
+
+def _torchaudio_honors_wav_encoding_args():
+    """Whether ``torchaudio.save()`` still respects ``encoding``/``bits_per_sample``.
+
+    torchaudio < 2.9 derives the WAV subtype from the input dtype, so float32 input
+    silently produces a 32-bit float WAV. We pass the arguments there to keep the
+    16-bit PCM output IndexTTS has always written.
+
+    torchaudio >= 2.9 delegates encoding to TorchCodec, which ignores both arguments
+    and warns when they are supplied. Its WAV default is already 16-bit signed PCM,
+    so we omit them instead of spamming a warning on every save.
+
+    An unparseable version is treated as the newer path: omitting the arguments is
+    harmless there, whereas passing them to TorchCodec always warns.
+    """
+    raw = getattr(torchaudio, "__version__", "") or ""
+    parts = []
+    for chunk in raw.split("+")[0].split(".")[:2]:
+        if not chunk.isdigit():
+            return False
+        parts.append(int(chunk))
+    return len(parts) == 2 and tuple(parts) < (2, 9)
+
+
+def save_pcm_wav(path, wav, sampling_rate):
+    """Write a **PCM-scale** waveform to ``path`` as a 16-bit PCM WAV file.
+
+    ``wav`` holds values in ``[-32767, 32767]`` and may be either an integer tensor
+    or the float tensor produced by ``torch.clamp(PCM16_MAX * wav, ...)``. It is
+    normalized to ``[-1, 1]`` float32 here, because that is the only input range
+    ``torchaudio.save()`` interprets identically across versions:
+
+    * torchaudio <= 2.8 rescales integer input by dtype range when encoding.
+    * torchaudio >= 2.9 routes through TorchCodec's ``AudioEncoder``, whose
+      compatibility shim does a bare ``src.float()`` with no rescaling and then
+      treats the result as ``[-1, 1]`` audio. Feeding it PCM-scale samples clips
+      almost every frame to full scale -- no exception, no warning, just a
+      saturated file (see index-tts/index-tts#724).
+
+    Do not pass an already-normalized waveform; it would be attenuated by 32767.
+    """
+    wav = wav.detach().to(device="cpu", dtype=torch.float32) / PCM16_MAX
+    wav = wav.clamp_(-1.0, 1.0)
+    encoding_args = {"encoding": "PCM_S", "bits_per_sample": 16} if _torchaudio_honors_wav_encoding_args() else {}
+    torchaudio.save(path, wav, sampling_rate, **encoding_args)
+
 
 def load_audio(audiopath, sampling_rate):
     audio, sr = torchaudio.load(audiopath)

--- a/tests/test_audio_save.py
+++ b/tests/test_audio_save.py
@@ -1,0 +1,194 @@
+"""Regression tests for the WAV save path (index-tts/index-tts#724).
+
+These are CPU-only and need no checkpoints, so they run in the `not gpu` CI job.
+
+Background: torchaudio >= 2.9 delegates ``torchaudio.save()`` to TorchCodec, whose
+compatibility shim converts non-float32 input with a bare ``src.float()`` -- no
+rescaling -- and then treats the result as ``[-1, 1]`` audio. Handing it the
+PCM-scale int16 tensor IndexTTS used to build clips nearly every frame to full
+scale, silently, with no exception or warning.
+
+Run with:
+    uv run --extra test pytest tests/test_audio_save.py -v
+"""
+import struct
+import warnings
+
+import pytest
+
+torch = pytest.importorskip("torch")
+torchaudio = pytest.importorskip("torchaudio")
+
+from indextts.utils.common import PCM16_MAX, save_pcm_wav  # noqa: E402
+
+SAMPLE_RATE = 24000
+
+
+def _reference_waveform():
+    """A normalized [-1, 1] stand-in for vocoder output, peaking at 0.8."""
+    t = torch.arange(SAMPLE_RATE, dtype=torch.float32) / SAMPLE_RATE
+    wave = (
+        0.72 * torch.sin(2 * torch.pi * 440.0 * t)
+        + 0.08 * torch.sin(2 * torch.pi * 997.0 * t)
+    ).clamp(-0.8, 0.8)
+    return wave.unsqueeze(0).contiguous()
+
+
+def _to_pcm_scale(normalized):
+    """Exactly the scaling the inference code applies before saving."""
+    return torch.clamp(PCM16_MAX * normalized, -PCM16_MAX, PCM16_MAX)
+
+
+def _read_wav(path):
+    """Parse a RIFF/WAVE file with no audio library, so the test can't be fooled
+    by the same normalization bug on the read side."""
+    blob = path.read_bytes()
+    assert blob[:4] == b"RIFF" and blob[8:12] == b"WAVE", "not a RIFF/WAVE file"
+
+    fmt = data = None
+    pos = 12
+    while pos + 8 <= len(blob):
+        chunk_id = blob[pos : pos + 4]
+        size = struct.unpack("<I", blob[pos + 4 : pos + 8])[0]
+        body = blob[pos + 8 : pos + 8 + size]
+        if chunk_id == b"fmt ":
+            fmt = body
+        elif chunk_id == b"data":
+            data = body
+        pos += 8 + size + (size & 1)  # chunks are word-aligned
+    assert fmt is not None and data is not None, "missing fmt / data chunk"
+
+    audio_format, channels, rate, _, _, bits = struct.unpack("<HHIIHH", fmt[:16])
+    if audio_format == 0xFFFE and len(fmt) >= 26:  # WAVE_FORMAT_EXTENSIBLE
+        audio_format = struct.unpack("<H", fmt[24:26])[0]
+
+    return {
+        "format": audio_format,  # 1 = integer PCM, 3 = IEEE float
+        "bits": bits,
+        "channels": channels,
+        "sample_rate": rate,
+        "samples": torch.frombuffer(bytearray(data), dtype=torch.int16),
+    }
+
+
+# -- the actual regression: no saturation on any torchaudio version -------------
+
+
+def test_save_pcm_wav_round_trips_without_saturation(tmp_path):
+    normalized = _reference_waveform()
+    out = tmp_path / "out.wav"
+
+    save_pcm_wav(str(out), _to_pcm_scale(normalized), SAMPLE_RATE)
+
+    wav = _read_wav(out)
+    assert wav["sample_rate"] == SAMPLE_RATE
+    assert wav["channels"] == 1
+
+    samples = wav["samples"]
+    assert samples.numel() == normalized.shape[-1]
+
+    # The reference peaks at 0.8, so nothing may land on a rail. Before the fix
+    # this was ~99.99% of frames on torchaudio >= 2.9.
+    at_full_scale = int(((samples <= -32768) | (samples >= 32767)).sum())
+    assert at_full_scale == 0, f"{at_full_scale}/{samples.numel()} samples clipped to full scale"
+
+    # Saturation also collapses the waveform onto a handful of levels.
+    assert len(set(samples.tolist())) > 1000, "amplitude information was destroyed"
+
+    # And the peak must still reflect the 0.8 input, not full scale.
+    peak = int(samples.abs().max())
+    assert 0.75 * 32767 < peak < 0.85 * 32767, f"unexpected peak {peak}"
+
+
+def test_save_pcm_wav_preserves_the_waveform_shape(tmp_path):
+    normalized = _reference_waveform()
+    out = tmp_path / "out.wav"
+
+    save_pcm_wav(str(out), _to_pcm_scale(normalized), SAMPLE_RATE)
+
+    decoded = _read_wav(out)["samples"].to(torch.float32) / 32768.0
+    expected = normalized[0]
+
+    # 16-bit quantization error is bounded by one LSB.
+    assert torch.allclose(decoded, expected, atol=2.0 / 32768.0)
+
+
+# -- keep the historical container format --------------------------------------
+
+
+def test_save_pcm_wav_writes_16_bit_integer_pcm(tmp_path):
+    """torchaudio < 2.9 picks the WAV subtype from the input dtype, so handing it
+    float32 without pinning the encoding would silently emit a 32-bit float WAV."""
+    out = tmp_path / "out.wav"
+    save_pcm_wav(str(out), _to_pcm_scale(_reference_waveform()), SAMPLE_RATE)
+
+    wav = _read_wav(out)
+    assert wav["format"] == 1, "expected integer PCM, got IEEE float"
+    assert wav["bits"] == 16, f"expected 16-bit samples, got {wav['bits']}"
+
+
+def test_save_pcm_wav_does_not_warn_about_ignored_encoding_args(tmp_path):
+    """torchaudio >= 2.9 warns when encoding/bits_per_sample are supplied, so they
+    must only be passed on versions that honour them.
+
+    Matched narrowly on TorchCodec's "The '<arg>' parameter is not ... supported"
+    wording; torchaudio 2.8 raises an unrelated blanket deprecation notice that
+    also happens to name these arguments, and that one is not ours to silence.
+    """
+    out = tmp_path / "out.wav"
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        save_pcm_wav(str(out), _to_pcm_scale(_reference_waveform()), SAMPLE_RATE)
+
+    offending = [
+        str(w.message)
+        for w in caught
+        if str(w.message).startswith("The '") and "parameter is not" in str(w.message)
+    ]
+    assert not offending, f"torchaudio ignored our encoding arguments: {offending}"
+
+
+# -- what is handed to torchaudio.save(): version-independent negative control --
+
+
+def test_save_pcm_wav_hands_normalized_float32_to_torchaudio(tmp_path, monkeypatch):
+    """The core contract, asserted without depending on the installed torchaudio.
+
+    TorchCodec requires float32 in [-1, 1]; anything else is silently clipped.
+    """
+    captured = {}
+
+    def spy(uri, src, sample_rate, **kwargs):
+        captured["src"] = src.clone()
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(torchaudio, "save", spy)
+    save_pcm_wav(str(tmp_path / "out.wav"), _to_pcm_scale(_reference_waveform()), SAMPLE_RATE)
+
+    src = captured["src"]
+    assert src.dtype == torch.float32, f"torchaudio.save() got {src.dtype}, not float32"
+    assert float(src.abs().max()) <= 1.0, f"samples out of [-1, 1]: peak {float(src.abs().max())}"
+    assert float(src.abs().max()) == pytest.approx(0.8, abs=1e-3), "amplitude was not preserved"
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64, torch.int16, torch.int32])
+def test_save_pcm_wav_normalizes_every_pcm_scale_dtype(tmp_path, monkeypatch, dtype):
+    """Call sites pass PCM-scale data as float32 *and* as int16; both must normalize."""
+    captured = {}
+    monkeypatch.setattr(torchaudio, "save", lambda uri, src, sr, **kw: captured.update(src=src.clone()))
+
+    save_pcm_wav(str(tmp_path / "out.wav"), _to_pcm_scale(_reference_waveform()).to(dtype), SAMPLE_RATE)
+
+    src = captured["src"]
+    assert src.dtype == torch.float32
+    assert float(src.abs().max()) == pytest.approx(0.8, abs=1e-3)
+
+
+def test_save_pcm_wav_does_not_mutate_the_caller_tensor(tmp_path):
+    """The inference code reuses `wav` after saving, so normalization must copy."""
+    pcm = _to_pcm_scale(_reference_waveform())
+    before = pcm.clone()
+
+    save_pcm_wav(str(tmp_path / "out.wav"), pcm, SAMPLE_RATE)
+
+    assert torch.equal(pcm, before), "save_pcm_wav modified its input in place"


### PR DESCRIPTION
## Description

Fixes #724.

`torchaudio.save()` was being handed a **PCM-scale `int16`** tensor at every save site. From torchaudio 2.9 onward, `save()` delegates to TorchCodec, and its compatibility shim does exactly this ([2.9 source](https://github.com/pytorch/audio/blob/v2.9.0/src/torchaudio/_torchcodec.py#L292-L293)):

```python
if src.dtype != torch.float32:
    src = src.float()
```

No rescaling. A sample of `26212` becomes `26212.0`, and `AudioEncoder` then interprets it as audio that should be in `[-1, 1]`. Everything is clipped to a rail. No exception, no warning — just a saturated file.

This PR normalizes to float32 `[-1, 1]` before saving, which is the one input range every torchaudio version interprets the same way.

### Why the encoding is pinned too

The workaround in the issue (normalize only) fixes the amplitude but introduces a second, quieter regression on the currently pinned torchaudio 2.8: below 2.9 the WAV subtype is derived from the **input dtype** ([`_get_subtype_for_wav`](https://github.com/pytorch/audio/blob/v2.8.0/src/torchaudio/_backend/soundfile_backend.py#L239-L252)), so float32 input silently produces a **32-bit IEEE float WAV** instead of the 16-bit PCM this project has always written. I measured that, and the regression test covers it:

```
torchaudio 2.8.0, normalize only, no encoding pinned
  -> IEEE_float32   (expected PCM_int16)
```

So `save_pcm_wav()` passes `encoding="PCM_S", bits_per_sample=16` on versions that honour them, and omits them on 2.9+ where they are [documented as ignored and warn if supplied](https://github.com/pytorch/audio/blob/v2.9.0/src/torchaudio/__init__.py#L117-L120) (TorchCodec's WAV default is already 16-bit signed PCM). Net effect: byte-identical container format on every version tested, and no new warnings.

### Changes

- `indextts/utils/common.py` — new `save_pcm_wav()` + `PCM16_MAX`, next to the existing `load_audio()`.
- Routed all six save sites through it:
  - `indextts/infer.py` (`infer_fast`, `infer`)
  - `indextts/infer_v2.py`
  - `indextts/infer_v2_5.py` (batch-concat path and main path)
  - `backends/trt/infer.py` (3 sites), `backends/trt/pipeline/pipeline.py` (`_save_wav`)

The issue only named `infer.py` and `infer_v2.py`; `infer_v2_5.py` and `backends/trt/` have the identical bug from the identical cause, so they are fixed in the same pass rather than left behind. `backends/trt/` pins `torchaudio>=2.7.1,<2.8`, which is also verified below.

The int16 NumPy return value used by the WebUI and the PCM-scale streaming output are **unchanged** — only the file-writing boundary moved.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation / comments only
- [ ] Build / CI / dependency change
- [ ] Refactor (no behaviour change)

## How has this been tested?

New file `tests/test_audio_save.py` — 10 CPU-only tests, no checkpoints, so they run in the existing `not gpu` CI job. The WAV reader in the test parses RIFF chunks by hand rather than using an audio library, so the same normalization bug cannot cancel itself out on the read side.

```bash
uv run --extra test pytest -m "not gpu"
```

**Full `not gpu` suite (torchaudio 2.8.0, the pinned version):**

```
163 passed, 22 deselected, 30 subtests passed in 25.17s
```

**The new tests across four torchaudio versions** (real CPU installs, TorchCodec + FFmpeg 7.1 present for 2.9/2.11):

| python | torchaudio | torchcodec | result |
|---|---|---|---|
| 3.10.20 | 2.8.0 | — | 10 passed |
| 3.12.13 | 2.7.1 | — | 10 passed |
| 3.12.13 | 2.8.0 | — | 10 passed |
| 3.12.13 | 2.9.0 | 0.9.1 | 10 passed |
| 3.12.13 | 2.11.0 | 0.16.0 | 10 passed |

The 3.10 row matches what `ci.yml` provisions. 2.7.1 covers the `backends/trt/` pin. The tests need a torchaudio save backend, which `soundfile` provides; it is a locked transitive dependency of both `librosa` and `descript-audiotools`, so it is always present.

**Negative control** — reverting `save_pcm_wav()` to the old `torchaudio.save(path, wav.type(torch.int16), sr)`:

| torchaudio | before fix | after fix |
|---|---|---|
| 2.8.0 | **5 failed**, 5 passed | 10 passed |
| 2.9.0 | **7 failed**, 3 passed | 10 passed |

Note the suite fails on 2.8 as well, even though 2.8's *output file* is fine. That is deliberate: the contract tests assert what is handed to `torchaudio.save()` rather than only inspecting the result, so CI (which runs 2.8) actually guards this instead of going green until someone bumps the pin.

Reverting to the issue's normalize-only workaround instead fails 3 tests on 2.8, catching the `IEEE_float` subtype change.

## Screenshots / output (if relevant)

Input is a 1 s 440 Hz + 997 Hz tone at 0.8 full scale, run through `torch.clamp(32767 * wav, -32767., 32767.)` exactly as the inference code does, then saved and re-read. Expected: `PCM_int16`, peak ≈ 26212, many distinct levels, 0 clipped frames.

```
torchaudio 2.7.1+cpu
  BEFORE (old code)      PCM_int16    peak=26211  levels=18846  clipped=0.000000  err=5.5e-05
  AFTER  (save_pcm_wav)  PCM_int16    peak=26212  levels=18898  clipped=0.000000  err=3.1e-05

torchaudio 2.8.0+cpu
  BEFORE (old code)      PCM_int16    peak=26211  levels=18846  clipped=0.000000  err=5.5e-05
  AFTER  (save_pcm_wav)  PCM_int16    peak=26212  levels=18898  clipped=0.000000  err=3.1e-05

torchaudio 2.9.0+cpu
  BEFORE (old code)      PCM_int16    peak=32767  levels=3      clipped=0.999875  err=0.999874   <-- broken
  AFTER  (save_pcm_wav)  PCM_int16    peak=26213  levels=18849  clipped=0.000000  err=1.5e-05

torchaudio 2.11.0+cpu
  BEFORE (old code)      PCM_int16    peak=32767  levels=3      clipped=0.999875  err=0.999874   <-- broken
  AFTER  (save_pcm_wav)  PCM_int16    peak=26213  levels=18849  clipped=0.000000  err=1.5e-05
```

`levels=3` on the broken rows means the entire waveform collapsed onto `{-32768, 0, 32767}` — this reproduces @John6666cat's reported figures (`unique_values: 3`, `fullscale_fraction: 0.999875`) exactly.

## Not verified

`backends/trt/` cannot be executed here — it needs TensorRT-LLM engines and an NVIDIA GPU. Those four call sites are changed by code review only. They are mechanical substitutions of the same pattern, and the tensors reaching them are documented and asserted as PCM-scale int16 in that code (`streaming.py::_to_int16` is `audio * 32767`, `pipeline.py` line 646 comment "int16-scale", and the `AudioOutput.audio: np.ndarray # int16` annotation), but a maintainer with TRT hardware should confirm one generated file.
