### PR TITLE
fix(webui): preview IndexTTS 2.5 text segments

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -1047,12 +1047,22 @@ with gr.Blocks(
                         outputs=example_outputs
     )
 
-    def on_input_text_change(text, max_text_tokens_per_segment):
+    def on_input_text_change(text, max_text_tokens_per_segment, lang_choice):
         if text and len(text) > 0:
             if IS_V25:
-                # v2.5 uses tiktoken encoder, no split_segments; show token count only
-                tokens = tts.tokenizer.encode(text, allowed_special='all')
-                data = [[0, text, len(tokens)]]
+                lang_prefix = f'<|{(lang_choice or "ZH").lower()}|> '
+                segments = tts.split_text_by_tokens(
+                    text,
+                    int(max_text_tokens_per_segment),
+                    lang_prefix,
+                )
+                data = []
+                for i, segment_str in enumerate(segments):
+                    tokens_count = len(tts.tokenizer.encode(
+                        lang_prefix + segment_str,
+                        allowed_special='all',
+                    ))
+                    data.append([i, segment_str, tokens_count])
             else:
                 text_tokens_list = tts.tokenizer.tokenize(text)
                 segments = tts.tokenizer.split_segments(text_tokens_list, max_text_tokens_per_segment=int(max_text_tokens_per_segment))
@@ -1186,15 +1196,22 @@ with gr.Blocks(
 
     input_text_single.change(
         on_input_text_change,
-        inputs=[input_text_single, max_text_tokens_per_segment],
+        inputs=[input_text_single, max_text_tokens_per_segment, lang_dropdown],
         outputs=[segments_preview]
     )
 
     max_text_tokens_per_segment.change(
         on_input_text_change,
-        inputs=[input_text_single, max_text_tokens_per_segment],
+        inputs=[input_text_single, max_text_tokens_per_segment, lang_dropdown],
         outputs=[segments_preview]
     )
+
+    if IS_V25:
+        lang_dropdown.change(
+            on_input_text_change,
+            inputs=[input_text_single, max_text_tokens_per_segment, lang_dropdown],
+            outputs=[segments_preview]
+        )
 
     prompt_audio.upload(update_prompt_audio,
                          inputs=[],


### PR DESCRIPTION
## Description

The IndexTTS-2.5 segment preview always displayed the entire input as a single row because the WebUI only encoded the full text for a token count. Actual inference already segments text with `IndexTTS2.split_text_by_tokens`, so changing **Max tokens per generation segment** affected generation but was not reflected in the preview.

This change:

- uses the same `split_text_by_tokens` implementation as IndexTTS-2.5 inference;
- includes the selected language prefix in the token budget and displayed token count; and
- refreshes the preview when the language changes.

The IndexTTS-2.0 preview path is unchanged.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation / comments only
- [ ] Build / CI / dependency change
- [ ] Refactor (no behaviour change)

## How has this been tested?

```bash
uv run --extra test pytest -m "not gpu" -v
```

Result: `153 passed, 22 deselected, 30 subtests passed`.

The WebUI was also tested locally with the same Chinese input:

- 20 tokens: 12 preview segments, each at or below 20 tokens
- 120 tokens: 2 preview segments
- 200 tokens: 1 preview segment (166 tokens)

## Checklist

- [x] Tests pass locally: `uv run pytest -m "not gpu"` (no GPU) or `uv run pytest tests/test_v2.py` (with GPU)
- [ ] I have added or updated tests to cover my changes (where applicable).
- [ ] I have added or updated docstrings for any changed public functions.

No public functions or docstrings were changed. Existing no-GPU segmentation tests cover the splitter used by this WebUI path, and the event wiring was verified in the live Gradio interface.

## Screenshots / output (if relevant)

Live WebUI verification showed the preview changing from 12 rows at 20 tokens, to 2 rows at 120 tokens, and to 1 row at 200 tokens.
