### PR TITLE
fix(webui): keep duration factor v2.5-only

### DIFF
--- a/tests/test_webui_syntax.py
+++ b/tests/test_webui_syntax.py
@@ -1,8 +1,76 @@
+import ast
 from pathlib import Path
 
 
-def test_webui_python_source_parses():
+def _webui_source():
     webui_path = Path(__file__).resolve().parents[1] / "webui.py"
-    source = webui_path.read_text(encoding="utf-8")
+    return webui_path, webui_path.read_text(encoding="utf-8")
+
+
+def test_webui_python_source_parses():
+    webui_path, source = _webui_source()
 
     assert compile(source, str(webui_path), "exec") is not None
+
+
+def test_duration_factor_is_only_forwarded_to_v25():
+    webui_path, source = _webui_source()
+    tree = ast.parse(source, filename=str(webui_path))
+    gen_single = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "gen_single"
+    )
+
+    infer_kwargs = next(
+        node.value for node in ast.walk(gen_single)
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "infer_kwargs" for target in node.targets)
+    )
+    assert isinstance(infer_kwargs, ast.Call)
+    assert "duration_factor" not in {
+        keyword.arg for keyword in infer_kwargs.keywords if keyword.arg is not None
+    }
+
+    v25_branch = next(
+        node for node in gen_single.body
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Name)
+        and node.test.id == "IS_V25"
+    )
+    forwarded_keys = {
+        target.slice.value
+        for statement in v25_branch.body
+        for target in getattr(statement, "targets", [])
+        if isinstance(target, ast.Subscript)
+        and isinstance(target.value, ast.Name)
+        and target.value.id == "infer_kwargs"
+        and isinstance(target.slice, ast.Constant)
+    }
+    assert {"lang", "duration_factor"} <= forwarded_keys
+
+
+def test_duration_factor_control_is_hidden_for_v2():
+    webui_path, source = _webui_source()
+    tree = ast.parse(source, filename=str(webui_path))
+
+    def assigned_component(statements, component_name):
+        return any(
+            isinstance(statement, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "duration_factor"
+                for target in statement.targets
+            )
+            and isinstance(statement.value, ast.Call)
+            and isinstance(statement.value.func, ast.Attribute)
+            and statement.value.func.attr == component_name
+            for statement in statements
+        )
+
+    duration_control = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Name)
+        and node.test.id == "IS_V25"
+        and assigned_component(node.body, "Slider")
+    )
+    assert assigned_component(duration_control.orelse, "State")

--- a/webui.py
+++ b/webui.py
@@ -680,11 +680,11 @@ def gen_single(emo_control_method,prompt, text,
         use_emo_text=(emo_control_method==3), emo_text=emo_text, use_random=emo_random,
         verbose=cmd_args.verbose,
         max_text_tokens_per_segment=int(max_text_tokens_per_segment),
-        duration_factor=float(duration_factor),
         **kwargs,
     )
     if IS_V25:
         infer_kwargs["lang"] = lang_choice or "ZH"
+        infer_kwargs["duration_factor"] = float(duration_factor)
     output = tts.infer(**infer_kwargs)
     return gr.update(value=output,visible=True)
 
@@ -804,11 +804,16 @@ with gr.Blocks(
                     )
                 else:
                     lang_dropdown = gr.State(value=None)
-                duration_factor = gr.Slider(
-                    label=i18n("时长系数"), minimum=0.5, maximum=2.0, value=1.0, step=0.01,
-                    info=f'{i18n("快")} ← — {i18n("不变")} — → {i18n("慢")}',
-                    key="duration_factor",
-                )
+                if IS_V25:
+                    duration_factor = gr.Slider(
+                        label=i18n("时长系数"), minimum=0.5, maximum=2.0, value=1.0, step=0.01,
+                        info=f'{i18n("快")} ← — {i18n("不变")} — → {i18n("慢")}',
+                        key="duration_factor",
+                    )
+                else:
+                    # Keep the shared callback input order stable without
+                    # exposing a v2.5-only control in the v2 WebUI.
+                    duration_factor = gr.State(value=1.0)
             with gr.Column(scale=1):
                 gen_button = gr.Button(
                     i18n("生成语音"), key="gen_button", interactive=True


### PR DESCRIPTION
## Description

The shared WebUI currently adds the IndexTTS-2.5-only `duration_factor` argument for both model versions. With `--version 2`, `infer_v2` forwards this unknown value through `generation_kwargs` to the Transformers `generate()` call, which can reject it as an unused model kwarg. The v2 UI also displays a duration control that v2 does not implement.

This change:

- only forwards `duration_factor` when `IS_V25` is true;
- only displays the duration-factor slider for IndexTTS-2.5; and
- keeps a hidden `gr.State` for v2 so the shared callback input order stays unchanged.

The IndexTTS-2.5 inference path and visible controls are unchanged.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation / comments only
- [ ] Build / CI / dependency change
- [ ] Refactor (no behaviour change)

## How has this been tested?

```bash
uv run --extra test pytest -m "not gpu" -v
```

Result: `155 passed, 22 deselected, 30 subtests passed`.

The two added regression tests verify that `duration_factor` is only forwarded inside the v2.5 branch and that the v2 WebUI uses hidden state instead of exposing the unsupported slider. The same WebUI fix has also been exercised by a real IndexTTS-2.0 MPS inference on Apple Silicon.

## Checklist

- [x] Tests pass locally: `uv run pytest -m "not gpu"` (no GPU) or `uv run pytest tests/test_v2.py` (with GPU)
- [x] I have added or updated tests to cover my changes (where applicable).
- [x] I have added or updated docstrings for any changed public functions. (N/A: no public functions changed.)

## Screenshots / output (if relevant)

Before this change, the v2 WebUI displayed a duration-factor slider even though v2 does not support that argument. After the change, the slider remains available for v2.5 and is absent when launching with `--version 2`.
