### PR TITLE
feat(inference): support a separate device for IndexTTS-2.5 reference encoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,25 @@ from indextts.infer_v2_5 import IndexTTS2
 tts = IndexTTS2(cfg_path="checkpoints/config.yaml", model_dir="checkpoints", use_bf16=True)
 ```
 
+On a low-VRAM GPU, IndexTTS-2.5 can keep the Wav2Vec2-BERT and CAMPPlus
+reference encoders on CPU while the synthesis models remain on the selected
+accelerator. Reference preparation takes longer and uses additional system RAM,
+but its cached conditioning tensors are moved to the synthesis device. Reference
+conditioning is recomputed on the selected backend, so results are not guaranteed
+to be bit-identical across devices:
+
+```python
+tts = IndexTTS2(
+    cfg_path="checkpoints/config.yaml",
+    model_dir="checkpoints",
+    device="cuda:0",
+    reference_device="cpu",
+)
+```
+
+The same option is available in the WebUI with
+`uv run webui.py --reference_device cpu`.
+
 #### 1. Voice cloning with a single reference audio
 
 ```python

--- a/indextts/infer_v2_5.py
+++ b/indextts/infer_v2_5.py
@@ -76,7 +76,8 @@ def apply_pronunciation_annotations(text: str) -> str:
 class IndexTTS2:
     def __init__(
             self, cfg_path="checkpoints/config.yaml", model_dir="checkpoints", use_bf16=False, device=None,
-            use_cuda_kernel=None,use_deepspeed=False, use_accel=False, use_torch_compile=False, use_qwen_emo=False
+            use_cuda_kernel=None,use_deepspeed=False, use_accel=False, use_torch_compile=False, use_qwen_emo=False,
+            reference_device=None
     ):
         """
         Args:
@@ -91,6 +92,12 @@ class IndexTTS2:
             use_qwen_emo (bool): if True, load the QwenEmotion text-to-emotion model.
                 Required for ``infer(..., use_emo_text=True)``. Attempting to use emotion-text
                 guidance when this is disabled will raise a RuntimeError.
+            reference_device (str): device used by the Wav2Vec2-BERT and CAMPPlus
+                reference encoders. Defaults to ``device``. Set this to ``"cpu"``
+                to keep reference-only models out of GPU memory; the resulting
+                conditioning tensors are moved to ``device`` before synthesis.
+                This trades system RAM and reference preparation latency for VRAM;
+                results are not guaranteed to be bit-identical across backends.
         """
         if device is not None:
             self.device = device
@@ -113,6 +120,10 @@ class IndexTTS2:
             self.use_bf16 = False
             self.use_cuda_kernel = False
             print(">> Be patient, it may take a while to run in CPU mode.")
+
+        self.reference_device = str(reference_device) if reference_device is not None else str(self.device)
+        if self.reference_device != str(self.device):
+            print(f">> Reference encoders will use {self.reference_device} (synthesis uses {self.device})")
 
         self.cfg = OmegaConf.load(cfg_path)
         self.model_dir = model_dir
@@ -173,11 +184,11 @@ class IndexTTS2:
             w2v_bert_dir = aux_paths["w2v_bert"]
         self.extract_features = SeamlessM4TFeatureExtractor.from_pretrained(w2v_bert_dir, local_files_only=True)
         self.semantic_model = Wav2Vec2BertModel.from_pretrained(w2v_bert_dir, local_files_only=True)
-        self.semantic_model = self.semantic_model.to(self.device)
+        self.semantic_model = self.semantic_model.to(self.reference_device)
         self.semantic_model.eval()
         stat_mean_var = torch.load(os.path.join(self.model_dir, self.cfg.w2v_stat))
-        self.semantic_mean = stat_mean_var["mean"].to(self.device)
-        self.semantic_std = torch.sqrt(stat_mean_var["var"]).to(self.device)
+        self.semantic_mean = stat_mean_var["mean"].to(self.reference_device)
+        self.semantic_std = torch.sqrt(stat_mean_var["var"]).to(self.reference_device)
 
         start_time = time.perf_counter()
         self.semantic_codec = EnhancedCodec(**self.cfg.semantic_codec, cfg=self.cfg.semantic_codec)
@@ -217,7 +228,7 @@ class IndexTTS2:
             campplus_ckpt_path = aux_paths["campplus"]
         campplus_model = CAMPPlus(feat_dim=80, embedding_size=192)
         campplus_model.load_state_dict(torch.load(campplus_ckpt_path, map_location="cpu"))
-        self.campplus_model = campplus_model.to(self.device)
+        self.campplus_model = campplus_model.to(self.reference_device)
         self.campplus_model.eval()
         print(">> campplus_model weights restored from:", campplus_ckpt_path)
 
@@ -288,6 +299,13 @@ class IndexTTS2:
         feat = vq_emb.hidden_states[17]  # (B, T, C)
         feat = (feat - self.semantic_mean) / self.semantic_std
         return feat
+
+    @torch.no_grad()
+    def _get_reference_embedding(self, audio_16k):
+        inputs = self.extract_features(audio_16k, sampling_rate=16000, return_tensors="pt")
+        input_features = inputs["input_features"].to(self.reference_device)
+        attention_mask = inputs["attention_mask"].to(self.reference_device)
+        return self.get_emb(input_features, attention_mask).to(self.device)
 
     @torch.no_grad()
     def get_scode(self, inputs):
@@ -407,6 +425,73 @@ class IndexTTS2:
                 print(f"Audio too long ({audio.shape[1]} samples), truncating to {max_audio_samples} samples")
             audio = audio[:, :max_audio_samples]
         return audio, sr
+
+    def _empty_cuda_cache(self):
+        devices = (str(self.device), str(self.reference_device))
+        if torch.cuda.is_available() and any(device.startswith("cuda") for device in devices):
+            torch.cuda.empty_cache()
+
+    @torch.no_grad()
+    def _prepare_speaker_reference(self, spk_audio_prompt, verbose=False):
+        if self.cache_spk_cond is None or self.cache_spk_audio_prompt != spk_audio_prompt:
+            if self.cache_spk_cond is not None:
+                self.cache_spk_cond = None
+                self.cache_s2mel_style = None
+                self.cache_s2mel_prompt = None
+                self.cache_mel = None
+                self._empty_cuda_cache()
+
+            audio, sr = self._load_and_cut_audio(spk_audio_prompt, 15, verbose)
+            audio_22k = torchaudio.transforms.Resample(sr, 22050)(audio)
+            audio_16k = torchaudio.transforms.Resample(sr, 16000)(audio)
+
+            # Keep the waveform used by CAMPPlus independent from feature
+            # extractor internals while avoiding a second file read/resample.
+            spk_cond_emb = self._get_reference_embedding(audio_16k.clone())
+            ref_mel = self.mel_fn(audio_22k.to(self.device).float())
+            ref_target_lengths = torch.LongTensor([ref_mel.size(2)]).to(self.device)
+
+            feat = torchaudio.compliance.kaldi.fbank(
+                audio_16k.to(self.device),
+                num_mel_bins=80,
+                dither=0,
+                sample_frequency=16000,
+            ).to(self.reference_device)
+            feat = feat - feat.mean(dim=0, keepdim=True)
+            style = self.campplus_model(feat.unsqueeze(0)).to(self.device)
+
+            prompt_condition = self.s2mel.models['length_regulator'](
+                spk_cond_emb,
+                ylens=ref_target_lengths,
+                n_quantizers=3,
+                f0=None,
+            )[0]
+
+            self.cache_spk_cond = spk_cond_emb
+            self.cache_s2mel_style = style
+            self.cache_s2mel_prompt = prompt_condition
+            self.cache_spk_audio_prompt = spk_audio_prompt
+            self.cache_mel = ref_mel
+
+        return (
+            self.cache_spk_cond,
+            self.cache_s2mel_style,
+            self.cache_s2mel_prompt,
+            self.cache_mel,
+        )
+
+    @torch.no_grad()
+    def _prepare_emotion_reference(self, emo_audio_prompt, verbose=False):
+        if self.cache_emo_cond is None or self.cache_emo_audio_prompt != emo_audio_prompt:
+            if self.cache_emo_cond is not None:
+                self.cache_emo_cond = None
+                self._empty_cuda_cache()
+
+            emo_audio, _ = self._load_and_cut_audio(emo_audio_prompt, 15, verbose, sr=16000)
+            self.cache_emo_cond = self._get_reference_embedding(emo_audio)
+            self.cache_emo_audio_prompt = emo_audio_prompt
+
+        return self.cache_emo_cond
 
     SPLIT_PROTECTED_PATTERN = re.compile(r'<\|SPECIAL_TOKEN_\d+\|>.*?<\|SPECIAL_TOKEN_\d+\|>')
 
@@ -616,55 +701,10 @@ class IndexTTS2:
             # must always use alpha=1.0 when we don't have an external reference voice
             emo_alpha = 1.0
 
-        # 如果参考音频改变了，才需要重新生成, 提升速度
-        if self.cache_spk_cond is None or self.cache_spk_audio_prompt != spk_audio_prompt:
-            if self.cache_spk_cond is not None:
-                self.cache_spk_cond = None
-                self.cache_s2mel_style = None
-                self.cache_s2mel_prompt = None
-                self.cache_mel = None
-                torch.cuda.empty_cache()
-            audio, sr = self._load_and_cut_audio(spk_audio_prompt, 15, verbose)
-            audio_22k = torchaudio.transforms.Resample(sr, 22050)(audio)
-            audio_16k = torchaudio.transforms.Resample(sr, 16000)(audio)
-
-            inputs = self.extract_features(audio_16k, sampling_rate=16000, return_tensors="pt")
-            input_features = inputs["input_features"]
-            attention_mask = inputs["attention_mask"]
-            input_features = input_features.to(self.device)
-            attention_mask = attention_mask.to(self.device)
-            spk_cond_emb = self.get_emb(input_features, attention_mask)
-
-            # _, S_ref = self.semantic_codec.quantize(spk_cond_emb)
-            S_ref = self.get_emb(input_features, attention_mask)
-            ref_mel = self.mel_fn(audio_22k.to(spk_cond_emb.device).float())
-            ref_target_lengths = torch.LongTensor([ref_mel.size(2)]).to(ref_mel.device)
-
-            audio_16k = torchaudio.transforms.Resample(sr, 16000)(self._load_and_cut_audio(spk_audio_prompt, 15, verbose)[0])
-            feat = torchaudio.compliance.kaldi.fbank(audio_16k.to(ref_mel.device),
-                                                    num_mel_bins=80,
-                                                    dither=0,
-                                                    sample_frequency=16000)
-            feat = feat - feat.mean(dim=0, keepdim=True)  # feat2另外一个滤波器能量组特征[922, 80]
-            style = self.campplus_model(feat.unsqueeze(0))  # 参考音频的全局style2[1,192]
-
-            prompt_condition = self.s2mel.models['length_regulator'](
-                # S_ref,
-                spk_cond_emb,
-                ylens=ref_target_lengths,
-                n_quantizers=3,
-                f0=None)[0]
-
-            self.cache_spk_cond = spk_cond_emb
-            self.cache_s2mel_style = style
-            self.cache_s2mel_prompt = prompt_condition
-            self.cache_spk_audio_prompt = spk_audio_prompt
-            self.cache_mel = ref_mel
-        else:
-            style = self.cache_s2mel_style
-            prompt_condition = self.cache_s2mel_prompt
-            spk_cond_emb = self.cache_spk_cond
-            ref_mel = self.cache_mel
+        spk_cond_emb, style, prompt_condition, ref_mel = self._prepare_speaker_reference(
+            spk_audio_prompt,
+            verbose,
+        )
 
         if emo_vector is not None:
             weight_vector = torch.tensor(emo_vector, device=self.device)
@@ -679,22 +719,9 @@ class IndexTTS2:
             emovec_mat = torch.sum(emovec_mat, 0)
             emovec_mat = emovec_mat.unsqueeze(0)
 
-        if self.cache_emo_cond is None or self.cache_emo_audio_prompt != emo_audio_prompt:
-            if self.cache_emo_cond is not None:
-                self.cache_emo_cond = None
-                torch.cuda.empty_cache()
-            emo_audio, _ = self._load_and_cut_audio(emo_audio_prompt,15,verbose,sr=16000)
-            emo_inputs = self.extract_features(emo_audio, sampling_rate=16000, return_tensors="pt")
-            emo_input_features = emo_inputs["input_features"]
-            emo_attention_mask = emo_inputs["attention_mask"]
-            emo_input_features = emo_input_features.to(self.device)
-            emo_attention_mask = emo_attention_mask.to(self.device)
-            emo_cond_emb = self.get_emb(emo_input_features, emo_attention_mask)
-
-            self.cache_emo_cond = emo_cond_emb
-            self.cache_emo_audio_prompt = emo_audio_prompt
-        else:
-            emo_cond_emb = self.cache_emo_cond
+        # Keep the legacy emotion path separate even when both paths are equal:
+        # speaker and emotion references currently use different resampling pipelines.
+        emo_cond_emb = self._prepare_emotion_reference(emo_audio_prompt, verbose)
 
         self._set_gr_progress(0.1, "text processing...")
         lang_prefix = f'<|{lang.lower()}|> '

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -256,6 +256,213 @@ def test_split_leaves_short_text_alone():
     assert splitter.split_text_by_tokens(text, 120, "<|zh|> ") == [text]
 
 
+# -- IndexTTS-2.5 reference preparation (no GPU) ------------------------------
+
+class _TrackingTensor:
+    def __init__(self, name):
+        self.name = name
+        self.moves = []
+
+    def to(self, device):
+        self.moves.append(str(device))
+        return self
+
+
+def test_25_reference_embedding_uses_separate_reference_device():
+    from indextts.infer_v2_5 import IndexTTS2
+
+    model = IndexTTS2.__new__(IndexTTS2)
+    model.reference_device = "cpu"
+    model.device = "cuda:0"
+
+    features = _TrackingTensor("features")
+    attention = _TrackingTensor("attention")
+    embedding = _TrackingTensor("embedding")
+
+    class _Extractor:
+        def __call__(self, audio, sampling_rate, return_tensors):
+            assert sampling_rate == 16000
+            assert return_tensors == "pt"
+            return {"input_features": features, "attention_mask": attention}
+
+    model.extract_features = _Extractor()
+
+    def get_emb(input_features, attention_mask):
+        assert input_features is features
+        assert attention_mask is attention
+        assert features.moves == ["cpu"]
+        assert attention.moves == ["cpu"]
+        return embedding
+
+    model.get_emb = get_emb
+
+    assert model._get_reference_embedding(object()) is embedding
+    assert embedding.moves == ["cuda:0"]
+
+
+def test_25_emotion_reference_cache_refreshes_only_when_path_changes():
+    from indextts.infer_v2_5 import IndexTTS2
+
+    model = IndexTTS2.__new__(IndexTTS2)
+    model.cache_emo_cond = None
+    model.cache_emo_audio_prompt = None
+    encoded = []
+    emptied = []
+
+    model._load_and_cut_audio = lambda path, *args, **kwargs: (f"audio:{path}", 16000)
+    model._get_reference_embedding = lambda audio: encoded.append(audio) or f"cond:{audio}"
+    model._empty_cuda_cache = lambda: emptied.append(True)
+
+    first = model._prepare_emotion_reference("emotion-a.wav")
+    assert model._prepare_emotion_reference("emotion-a.wav") == first
+    second = model._prepare_emotion_reference("emotion-b.wav")
+
+    assert first == "cond:audio:emotion-a.wav"
+    assert second == "cond:audio:emotion-b.wav"
+    assert encoded == ["audio:emotion-a.wav", "audio:emotion-b.wav"]
+    assert emptied == [True]
+
+
+def test_25_speaker_reference_cache_hit_skips_preprocessing():
+    from indextts.infer_v2_5 import IndexTTS2
+
+    model = IndexTTS2.__new__(IndexTTS2)
+    model.cache_spk_audio_prompt = "speaker.wav"
+    model.cache_spk_cond = "spk"
+    model.cache_s2mel_style = "style"
+    model.cache_s2mel_prompt = "prompt"
+    model.cache_mel = "mel"
+    model._load_and_cut_audio = lambda *args, **kwargs: (_ for _ in ()).throw(
+        AssertionError("cache hit must not reload the speaker reference")
+    )
+
+    assert model._prepare_speaker_reference("speaker.wav") == (
+        "spk",
+        "style",
+        "prompt",
+        "mel",
+    )
+
+
+def test_25_speaker_reference_cache_miss_routes_devices(monkeypatch):
+    import indextts.infer_v2_5 as infer_v25
+
+    events = []
+
+    class _Tensor:
+        def __init__(self, name, device=None):
+            self.name = name
+            self.device = device
+
+        def to(self, device):
+            self.device = str(device)
+            events.append(("to", self.name, self.device))
+            return self
+
+        def clone(self):
+            events.append(("clone", self.name))
+            return _Tensor(f"{self.name}-clone", self.device)
+
+        def float(self):
+            return self
+
+        def size(self, dim):
+            assert dim == 2
+            return 42
+
+        def mean(self, *args, **kwargs):
+            return _Tensor(f"{self.name}-mean", self.device)
+
+        def __sub__(self, other):
+            return self
+
+        def unsqueeze(self, dim):
+            events.append(("unsqueeze", self.name, dim))
+            return self
+
+    class _Resample:
+        def __init__(self, source_rate, target_rate):
+            self.target_rate = target_rate
+            events.append(("resample-init", source_rate, target_rate))
+
+        def __call__(self, audio):
+            events.append(("resample", self.target_rate))
+            return _Tensor(f"audio-{self.target_rate}", "cpu")
+
+    monkeypatch.setattr(infer_v25.torchaudio.transforms, "Resample", _Resample)
+
+    def fbank(audio, **kwargs):
+        assert audio.device == "cuda:0"
+        events.append(("fbank", audio.device, kwargs["sample_frequency"]))
+        return _Tensor("fbank", audio.device)
+
+    monkeypatch.setattr(infer_v25.torchaudio.compliance.kaldi, "fbank", fbank)
+    monkeypatch.setattr(infer_v25.torch, "LongTensor", lambda values: _Tensor("lengths"))
+
+    model = infer_v25.IndexTTS2.__new__(infer_v25.IndexTTS2)
+    model.device = "cuda:0"
+    model.reference_device = "cpu"
+    model.cache_spk_cond = None
+    model.cache_s2mel_style = None
+    model.cache_s2mel_prompt = None
+    model.cache_spk_audio_prompt = None
+    model.cache_mel = None
+    model._empty_cuda_cache = lambda: events.append(("empty-cache",))
+
+    loads = []
+    model._load_and_cut_audio = lambda path, *args, **kwargs: (
+        loads.append(path) or _Tensor("audio", "cpu"),
+        22050,
+    )
+
+    embeddings = []
+
+    def get_embedding(audio):
+        embeddings.append(audio.name)
+        return _Tensor("spk", "cuda:0")
+
+    model._get_reference_embedding = get_embedding
+
+    def mel_fn(audio):
+        assert audio.device == "cuda:0"
+        events.append(("mel", audio.device))
+        return _Tensor("mel", audio.device)
+
+    model.mel_fn = mel_fn
+
+    class _CampPlus:
+        def __call__(self, feat):
+            assert feat.device == "cpu"
+            events.append(("campplus", feat.device))
+            return _Tensor("style", "cpu")
+
+    model.campplus_model = _CampPlus()
+
+    def length_regulator(spk_cond, ylens, **kwargs):
+        assert spk_cond.device == "cuda:0"
+        assert ylens.device == "cuda:0"
+        events.append(("length-regulator", spk_cond.device, ylens.device))
+        return [_Tensor("prompt", "cuda:0")]
+
+    model.s2mel = types.SimpleNamespace(models={"length_regulator": length_regulator})
+
+    spk, style, prompt, mel = model._prepare_speaker_reference("speaker.wav")
+
+    assert loads == ["speaker.wav"]
+    assert embeddings == ["audio-16000-clone"]
+    assert [event for event in events if event[0] == "resample"] == [
+        ("resample", 22050),
+        ("resample", 16000),
+    ]
+    assert ("mel", "cuda:0") in events
+    assert ("fbank", "cuda:0", 16000) in events
+    assert ("to", "fbank", "cpu") in events
+    assert ("campplus", "cpu") in events
+    assert ("to", "style", "cuda:0") in events
+    assert ("length-regulator", "cuda:0", "cuda:0") in events
+    assert (spk.name, style.name, prompt.name, mel.name) == ("spk", "style", "prompt", "mel")
+
+
 def _load_qwen_emotion_module(module_name, monkeypatch):
     class _Dummy:
         def __init__(self, *args, **kwargs):

--- a/webui.py
+++ b/webui.py
@@ -32,8 +32,12 @@ parser.add_argument("--cuda_kernel", action="store_true", default=False, help="U
 parser.add_argument("--accel", action="store_true", default=False, help="Use GPT2 acceleration engine if available")
 parser.add_argument("--torch_compile", action="store_true", default=False, help="Use torch.compile to optimize s2mel if available")
 parser.add_argument("--qwen_emo", action="store_true", default=False, help="Load QwenEmotion even on a low-VRAM GPU, where it is skipped by default")
+parser.add_argument("--reference_device", type=str, default=None, help="IndexTTS-2.5: device for Wav2Vec2-BERT and CAMPPlus reference encoders (for example, cpu)")
 parser.add_argument("--gui_seg_tokens", type=int, default=120, help="GUI: Max tokens per generation segment")
 cmd_args = parser.parse_args()
+IS_V25 = cmd_args.version == "2.5"
+if cmd_args.reference_device is not None and not IS_V25:
+    parser.error("--reference_device is only supported with --version 2.5")
 
 # Validate optional acceleration dependencies early, so missing extras fail
 # at startup instead of halfway through inference.
@@ -91,8 +95,6 @@ try:
 except Exception as e:
     print(f"Failed to download config.yaml: {e}")
     sys.exit(1)
-
-IS_V25 = cmd_args.version == "2.5"
 
 import gradio as gr
 from indextts.utils.examples_downloader import ensure_examples_available
@@ -155,6 +157,7 @@ def build_tts(use_accel=False, use_torch_compile=False):
         if HALF_PRECISION and not use_bf16:
             print(">> BF16 is not supported on this device, falling back to full precision.")
         kwargs["use_bf16"] = use_bf16
+        kwargs["reference_device"] = cmd_args.reference_device
     else:
         kwargs["use_fp16"] = HALF_PRECISION
     return IndexTTS2(**kwargs)


### PR DESCRIPTION
## Description

IndexTTS-2.5 currently places Wav2Vec2-BERT, its normalization statistics, and CAMPPlus on the synthesis device even though they are only used when a speaker or emotion reference cache misses. This is a substantial persistent VRAM cost for 6-8 GB GPUs and for applications that share a GPU with another workload.

This PR adds an opt-in `reference_device` argument to `IndexTTS2`. With `reference_device="cpu"`:

- Wav2Vec2-BERT, its statistics, and CAMPPlus stay on CPU.
- Mel/fbank preprocessing keeps the existing synthesis-device path to minimize numerical changes.
- Only the resulting speaker/emotion/style conditioning tensors are copied to the synthesis device.
- Dynamic speaker and independent emotion references continue to work through the existing per-instance caches.

The default remains `reference_device=None`, which resolves to the synthesis device and preserves existing placement. The WebUI exposes the option as `--reference_device cpu` and rejects it for IndexTTS 2.0.

The reference preparation refactor also removes one unused duplicate Wav2Vec forward pass and a duplicate speaker WAV load/resample. Speaker and emotion extraction remain separate even when they use the same path because their existing resampling pipelines differ.

Trade-off: CPU reference encoding uses additional system RAM and makes the first preparation (and later reference changes) slower. Different backends are not guaranteed to produce bit-identical conditioning. Synthesis after the existing in-memory cache is warm is unchanged.

Related to #649, but this does not claim to free all idle VRAM or unload synthesis models.

### Prior low-VRAM evidence

A downstream prototype motivated this change on a GTX 1060 6 GB (sm_61, Windows, PyTorch 2.8.0+cu128, QwenEmotion/acceleration disabled):

| Layout | PyTorch allocated / reserved after initialization |
| --- | ---: |
| Stock FP32, all models on CUDA | 6630 / 6754 MiB |
| FP32 synthesis models only; reference encoders not resident on CUDA | 4339 / 4454 MiB |

This is historical evidence for the steady-state cost of the reference-only models, not a benchmark of this exact branch: that prototype prepared a fixed reference with staged CUDA execution, while this PR computes cache misses on `reference_device`. I did not rerun a checkpoint/GPU benchmark during the current live workload, and I do not have a multi-GPU hardware matrix. Community validation on Pascal/Turing/Ampere cards, dynamic references, and output similarity would be welcome, but is not required by the implementation.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change or feature that changes existing behaviour
- [ ] Documentation / comments only
- [ ] Build / CI / dependency change
- [ ] Refactor (no behaviour change)

## How has this been tested?

Validation covers static/mock paths and an exact-head checkpoint/CUDA run:

- Python AST parsing for `infer_v2_5.py`, `webui.py`, and `tests/test_v2.py`.
- Four targeted no-GPU tests covering reference/synthesis device routing, emotion cache refresh, speaker cache hits, and the full mocked speaker cache-miss pipeline: **4 passed** on Windows.
- Exact head `7a72015226fbf1505fedd5835bb89f494a313077` loaded the IndexTTS-2.5 checkpoints on a GTX 1060 6 GB with `device="cuda:0"`, `reference_device="cpu"`, and FP32. Two WAVs were generated successfully, including dynamic speaker and independent emotion-reference cache changes.
- `git diff --check`.

The repository's full `uv run --extra test pytest -m "not gpu" -v` suite was not run locally. The checklist remains unchecked because the local pytest run selected only the four PR-specific nodes; the PR CI is expected to run the complete no-GPU suite on Linux and Windows.

## Checklist

- [ ] Tests pass locally: `uv run pytest -m "not gpu"` (no GPU) or `uv run pytest tests/test_v2.py` (with GPU)
- [x] I have added or updated tests to cover my changes (where applicable).
- [x] I have added or updated docstrings for any changed public functions.

## Screenshots / output (if relevant)

Not applicable.
### Exact-branch hardware validation (2026-08-26)

The exact PR head `7a72015226fbf1505fedd5835bb89f494a313077` was tested with real IndexTTS-2.5 checkpoints and CUDA inference.

| Environment | Value |
| --- | --- |
| OS | Windows 10 Pro for Workstations 10.0.18363 |
| GPU / driver | NVIDIA GeForce GTX 1060 6 GB / 582.66 |
| Python / PyTorch | 3.11.13 / 2.8.0+cu128 |
| Configuration | `device="cuda:0"`, `reference_device="cpu"`, FP32; QwenEmotion, DeepSpeed, acceleration, compile, and custom CUDA kernel disabled |

Placement assertions passed: GPT, semantic codec, S2Mel, and BigVGAN were on `cuda:0`; Wav2Vec2-BERT, CAMPPlus, semantic mean, and semantic std were on CPU. Initialization completed in 33.969 s at 4389.6/4498.0 MiB PyTorch allocated/reserved (4425.1 MiB peak allocated).

| Operation | Time | Peak allocated / reserved |
| --- | ---: | ---: |
| First speaker reference cache miss (15 s WAV, cold) | 19.644 s | 4413.6 / 4500.0 MiB |
| Same speaker cache hit | <0.001 s | 4404.1 / 4500.0 MiB |
| First default emotion-reference cache miss | 8.175 s | 4407.3 / 4500.0 MiB |
| Same emotion cache hit | <0.001 s | 4407.3 / 4500.0 MiB |
| Dynamic speaker change cache miss | 8.617 s | 4542.0 / 5296.0 MiB* |
| Dynamic speaker cache hit | <0.001 s | 4527.1 / 4876.0 MiB |
| Independent emotion-reference change cache miss | 8.229 s | 4530.0 / 4876.0 MiB* |
| Independent emotion cache hit | <0.001 s | 4530.0 / 4874.0 MiB |

`*` The reserved-memory peak can retain the preceding inference's cached reservation; allocated memory is the more useful per-step signal.

Two warm-cache synthesis checks completed without CUDA/OOM errors:

| Case | Wall time | WAV | PyTorch peak allocated / reserved |
| --- | ---: | --- | ---: |
| Default emotion fallback using the speaker reference | 14.820 s | 2.508 s, 110,636 bytes | 5157.0 / 5296.0 MiB |
| Dynamic speaker plus an independent emotion reference | 13.736 s | 1.939 s, 85,548 bytes | 5279.7 / 5662.0 MiB |

Both outputs were finite, non-silent 22,050 Hz mono WAVs. The test asserted that repeated reference calls returned the same cached tensor objects and that changing speaker/emotion paths refreshed the corresponding caches. The model process exited cleanly and released its CUDA allocation.

The 5,662 MiB maximum PyTorch reservation shows that FP32 on a 6 GB WDDM/Pascal card has very little headroom, but the exact branch completed both paths without OOM. This was a functional smoke test, not a perceptual A/B or cross-GPU benchmark. The all-CUDA baseline was not rerun because the historical stock measurement already exceeded this card's capacity. The full no-GPU suite remains CI-owned.

For longer-run context only, the separate downstream FP16 deployment has also completed 99 consecutive cached-reference syntheses with no synthesis/CUDA/OOM failures. That soak is not used as an exact-branch benchmark.