### PR TITLE
feat(inference): support FP16 fallback for IndexTTS-2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,20 @@ from indextts.infer_v2_5 import IndexTTS2
 tts = IndexTTS2(cfg_path="checkpoints/config.yaml", model_dir="checkpoints", use_bf16=True)
 ```
 
+IndexTTS2.5 can alternatively use FP16 for its UnifiedVoice/GPT stack on CUDA
+devices without native BF16 support:
+
+```python
+tts = IndexTTS2(cfg_path="checkpoints/config.yaml", model_dir="checkpoints", use_fp16=True)
+```
+
+`use_fp16` and `use_bf16` are mutually exclusive and both default to `False`.
+The semantic codec, S2Mel, BigVGAN, and reference encoders remain in full
+precision. FP16 reduces GPT memory use, but it does not reduce the model's
+mathematical operation count or guarantee faster or numerically identical
+output. The WebUI's existing `--fp16` option prefers native BF16 and falls back
+to FP16 when native BF16 is unavailable.
+
 #### 1. Voice cloning with a single reference audio
 
 ```python

--- a/indextts/infer_v2_5.py
+++ b/indextts/infer_v2_5.py
@@ -25,6 +25,7 @@ from indextts.utils.front import TextNormalizer
 from indextts.utils.tokenizer import get_tokenizer, lang_to_token
 from indextts.utils.ja_g2p import JapaneseG2PProcessor
 from indextts.utils.nemo_tn import normalize_text as nemo_text_normalize
+from indextts.utils.precision import resolve_gpt_precision
 
 from indextts.s2mel.modules.commons import load_checkpoint2, MyModel
 from indextts.s2mel.modules.bigvgan import bigvgan
@@ -76,13 +77,14 @@ def apply_pronunciation_annotations(text: str) -> str:
 class IndexTTS2:
     def __init__(
             self, cfg_path="checkpoints/config.yaml", model_dir="checkpoints", use_bf16=False, device=None,
-            use_cuda_kernel=None,use_deepspeed=False, use_accel=False, use_torch_compile=False, use_qwen_emo=False
+            use_cuda_kernel=None,use_deepspeed=False, use_accel=False, use_torch_compile=False, use_qwen_emo=False,
+            use_fp16=False
     ):
         """
         Args:
             cfg_path (str): path to the config file.
             model_dir (str): path to the model directory.
-            use_bf16 (bool): whether to use bf16.
+            use_bf16 (bool): whether to use BF16 for the UnifiedVoice/GPT stack.
             device (str): device to use (e.g., 'cuda:0', 'cpu'). If None, it will be set automatically based on the availability of CUDA or MPS.
             use_cuda_kernel (None | bool): whether to use BigVGan custom fused activation CUDA kernel, only for CUDA device.
             use_deepspeed (bool): whether to use DeepSpeed or not.
@@ -91,32 +93,43 @@ class IndexTTS2:
             use_qwen_emo (bool): if True, load the QwenEmotion text-to-emotion model.
                 Required for ``infer(..., use_emo_text=True)``. Attempting to use emotion-text
                 guidance when this is disabled will raise a RuntimeError.
+            use_fp16 (bool): whether to use FP16 for the UnifiedVoice/GPT stack.
+                Mutually exclusive with ``use_bf16``. The semantic codec, S2Mel,
+                BigVGAN, and reference encoders remain in full precision.
         """
         if device is not None:
             self.device = device
-            self.use_bf16 = False if device == "cpu" else use_bf16
             self.use_cuda_kernel = use_cuda_kernel is not None and use_cuda_kernel and device.startswith("cuda")
         elif torch.cuda.is_available():
             self.device = "cuda:0"
-            self.use_bf16 = use_bf16
             self.use_cuda_kernel = use_cuda_kernel is None or use_cuda_kernel
         elif hasattr(torch, "xpu") and torch.xpu.is_available():
             self.device = "xpu"
-            self.use_bf16 = use_bf16
             self.use_cuda_kernel = False
         elif hasattr(torch, "mps") and torch.backends.mps.is_available():
             self.device = "mps"
-            self.use_bf16 = False  # Use bfloat16 on MPS is overhead than float32
             self.use_cuda_kernel = False
         else:
             self.device = "cpu"
-            self.use_bf16 = False
             self.use_cuda_kernel = False
             print(">> Be patient, it may take a while to run in CPU mode.")
 
+        precision = resolve_gpt_precision(
+            use_fp16=use_fp16,
+            use_bf16=use_bf16,
+            device=self.device,
+        )
+        self.use_fp16 = precision == "fp16"
+        self.use_bf16 = precision == "bf16"
+
         self.cfg = OmegaConf.load(cfg_path)
         self.model_dir = model_dir
-        self.dtype = torch.bfloat16 if self.use_bf16 else None
+        if self.use_fp16:
+            self.dtype = torch.float16
+        elif self.use_bf16:
+            self.dtype = torch.bfloat16
+        else:
+            self.dtype = None
         self.stop_mel_token = self.cfg.gpt.stop_mel_token
         self.use_accel = use_accel
         self.use_torch_compile = use_torch_compile
@@ -139,11 +152,11 @@ class IndexTTS2:
         self.gpt = UnifiedVoice(**self.cfg.gpt, use_accel=self.use_accel, spk_cond_mode="campplus")
         self.gpt_path = os.path.join(self.model_dir, self.cfg.gpt_checkpoint)
         load_checkpoint(self.gpt, self.gpt_path)
-        self.gpt = self.gpt.to(self.device)
-        if self.use_bf16:
-            self.gpt.eval().bfloat16()
-        else:
-            self.gpt.eval()
+        if self.dtype is not None:
+            # Cast on CPU before moving to the accelerator so low-VRAM devices
+            # never need to hold a complete FP32 GPT stack during startup.
+            self.gpt = self.gpt.to(dtype=self.dtype)
+        self.gpt = self.gpt.to(self.device).eval()
         print(">> GPT weights restored from:", self.gpt_path)
 
         if use_deepspeed:
@@ -153,7 +166,7 @@ class IndexTTS2:
                 use_deepspeed = False
                 print(f">> Failed to load DeepSpeed. Falling back to normal inference. Error: {e}")
 
-        self.gpt.post_init_gpt2_config(use_deepspeed=use_deepspeed, kv_cache=True, half=self.use_bf16)
+        self.gpt.post_init_gpt2_config(use_deepspeed=use_deepspeed, kv_cache=True, half=self.dtype is not None)
 
         if self.use_cuda_kernel:
             # preload the CUDA kernel for BigVGAN

--- a/indextts/utils/precision.py
+++ b/indextts/utils/precision.py
@@ -1,0 +1,30 @@
+"""Precision selection helpers shared by inference entry points and the WebUI."""
+
+
+def resolve_gpt_precision(*, use_fp16=False, use_bf16=False, device=None):
+    """Return the requested GPT precision, after applying device constraints."""
+    if use_fp16 and use_bf16:
+        raise ValueError("use_fp16 and use_bf16 are mutually exclusive")
+
+    device_type = str(device).split(":", 1)[0] if device is not None else None
+    if device_type in {"cpu", "mps"}:
+        return None
+    if use_fp16:
+        return "fp16"
+    if use_bf16:
+        return "bf16"
+    return None
+
+
+def select_half_precision(*, enabled, cuda_available, native_bf16_supported):
+    """Prefer native BF16 for half precision, otherwise fall back to FP16."""
+    if not enabled or not cuda_available:
+        return None
+    return "bf16" if native_bf16_supported else "fp16"
+
+
+def cuda_supports_native_bf16(torch_module):
+    """Return whether CUDA provides native BF16 rather than software emulation."""
+    if not torch_module.cuda.is_available():
+        return False
+    return torch_module.cuda.is_bf16_supported(including_emulation=False)

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -7,6 +7,7 @@ Run with:
 CI only (no GPU):
     uv run --extra test pytest tests/test_v2.py -v -m "not gpu"
 """
+import ast
 import importlib
 import sys
 import types
@@ -174,6 +175,118 @@ def test_modelscope_single_file_download_matches_local_path(tmp_path, monkeypatc
     assert got == str(local_path)
     assert local_path.exists()
     assert local_path.read_bytes() == expected_bytes
+
+
+# -- IndexTTS 2.5 precision selection (no GPU) --------------------------------
+
+def test_25_use_fp16_is_appended_to_constructor_signature():
+    """The new option must not shift any existing positional arguments."""
+    source = Path("indextts/infer_v2_5.py").read_text(encoding="utf-8")
+    module = ast.parse(source)
+    cls = next(node for node in module.body if isinstance(node, ast.ClassDef) and node.name == "IndexTTS2")
+    init = next(node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == "__init__")
+
+    original_args = [
+        "self", "cfg_path", "model_dir", "use_bf16", "device", "use_cuda_kernel",
+        "use_deepspeed", "use_accel", "use_torch_compile", "use_qwen_emo",
+    ]
+    arg_names = [arg.arg for arg in init.args.args]
+    assert arg_names[:len(original_args)] == original_args
+    assert arg_names[len(original_args)] == "use_fp16"
+
+    default_offset = len(arg_names) - len(init.args.defaults)
+    fp16_default = init.args.defaults[arg_names.index("use_fp16") - default_offset]
+    assert isinstance(fp16_default, ast.Constant)
+    assert fp16_default.value is False
+
+
+@pytest.mark.parametrize(
+    "use_fp16,use_bf16,device,expected",
+    [
+        (False, False, "cuda:0", None),
+        (True, False, "cuda:0", "fp16"),
+        (False, True, "cuda:0", "bf16"),
+        (True, False, "xpu", "fp16"),
+        (False, True, "xpu", "bf16"),
+        (True, False, "cpu", None),
+        (False, True, "cpu:0", None),
+        (True, False, "mps", None),
+        (False, True, "mps:0", None),
+    ],
+)
+def test_25_resolve_gpt_precision(use_fp16, use_bf16, device, expected):
+    from indextts.utils.precision import resolve_gpt_precision
+
+    assert resolve_gpt_precision(
+        use_fp16=use_fp16,
+        use_bf16=use_bf16,
+        device=device,
+    ) == expected
+
+
+def test_25_rejects_fp16_and_bf16_together():
+    from indextts.utils.precision import resolve_gpt_precision
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        resolve_gpt_precision(use_fp16=True, use_bf16=True, device="cuda:0")
+
+
+@pytest.mark.parametrize(
+    "enabled,cuda_available,native_bf16_supported,expected",
+    [
+        (False, False, False, None),
+        (False, True, True, None),
+        (True, False, False, None),
+        (True, True, False, "fp16"),
+        (True, True, True, "bf16"),
+    ],
+)
+def test_25_selects_webui_half_precision(
+        enabled, cuda_available, native_bf16_supported, expected
+):
+    from indextts.utils.precision import select_half_precision
+
+    assert select_half_precision(
+        enabled=enabled,
+        cuda_available=cuda_available,
+        native_bf16_supported=native_bf16_supported,
+    ) == expected
+
+
+def test_25_native_bf16_check_disables_emulation():
+    from indextts.utils.precision import cuda_supports_native_bf16
+
+    calls = []
+
+    def is_bf16_supported(**kwargs):
+        calls.append(kwargs)
+        return True
+
+    torch_stub = types.SimpleNamespace(
+        cuda=types.SimpleNamespace(
+            is_available=lambda: True,
+            is_bf16_supported=is_bf16_supported,
+        )
+    )
+
+    assert cuda_supports_native_bf16(torch_stub) is True
+    assert calls == [{"including_emulation": False}]
+
+
+def test_25_native_bf16_check_skips_non_cuda_devices():
+    from indextts.utils.precision import cuda_supports_native_bf16
+
+    def unexpected_probe(**kwargs):
+        raise AssertionError("BF16 support should not be probed without CUDA")
+
+    torch_stub = types.SimpleNamespace(
+        cuda=types.SimpleNamespace(
+            is_available=lambda: False,
+            is_bf16_supported=unexpected_probe,
+        )
+    )
+
+    assert cuda_supports_native_bf16(torch_stub) is False
 
 
 # -- Text segmentation (no GPU) -----------------------------------------------

--- a/webui.py
+++ b/webui.py
@@ -16,6 +16,8 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(current_dir)
 sys.path.append(os.path.join(current_dir, "indextts"))
 
+from indextts.utils.precision import cuda_supports_native_bf16, select_half_precision
+
 import argparse
 parser = argparse.ArgumentParser(
     description="IndexTTS WebUI",
@@ -26,7 +28,7 @@ parser.add_argument("--port", type=int, default=7860, help="Port to run the web 
 parser.add_argument("--host", type=str, default="0.0.0.0", help="Host to run the web UI on")
 parser.add_argument("--model_dir", type=str, default="./checkpoints", help="Model checkpoints directory")
 parser.add_argument("--version", type=str, default="2.5", choices=["2", "2.5"], help="Model version to use")
-parser.add_argument("--fp16", action="store_true", default=False, help="Use FP16 for inference if available")
+parser.add_argument("--fp16", action="store_true", default=False, help="Use half precision for inference if available")
 parser.add_argument("--deepspeed", action="store_true", default=False, help="Use DeepSpeed to accelerate if available")
 parser.add_argument("--cuda_kernel", action="store_true", default=False, help="Use CUDA kernel for inference if available")
 parser.add_argument("--accel", action="store_true", default=False, help="Use GPT2 acceleration engine if available")
@@ -151,10 +153,16 @@ def build_tts(use_accel=False, use_torch_compile=False):
         use_qwen_emo=LOAD_QWEN_EMO,
     )
     if IS_V25:
-        use_bf16 = HALF_PRECISION and torch.cuda.is_bf16_supported()
-        if HALF_PRECISION and not use_bf16:
-            print(">> BF16 is not supported on this device, falling back to full precision.")
-        kwargs["use_bf16"] = use_bf16
+        cuda_available = torch.cuda.is_available()
+        precision = select_half_precision(
+            enabled=HALF_PRECISION,
+            cuda_available=cuda_available,
+            native_bf16_supported=cuda_supports_native_bf16(torch),
+        )
+        kwargs["use_fp16"] = precision == "fp16"
+        kwargs["use_bf16"] = precision == "bf16"
+        if precision is not None:
+            print(f">> IndexTTS-2.5 UnifiedVoice/GPT stack will use {precision.upper()}.")
     else:
         kwargs["use_fp16"] = HALF_PRECISION
     return IndexTTS2(**kwargs)


### PR DESCRIPTION
## Description

IndexTTS-2.5 currently exposes BF16 as its only reduced-precision option. The
WebUI enables half precision automatically below 10 GB VRAM, but its
`torch.cuda.is_bf16_supported()` probe includes software emulation by default in
PyTorch 2.8. Older CUDA devices can therefore be routed to emulated BF16 even
though they support FP16 inference.

This adds an opt-in FP16 path for the existing IndexTTS-2.5 UnifiedVoice/GPT
precision boundary and makes the WebUI prefer native BF16, falling back to FP16
when native BF16 is unavailable.

### Changes

- Add `use_fp16=False` at the end of the `IndexTTS2` constructor signature so
  existing positional calls remain compatible.
- Reject `use_fp16=True` together with `use_bf16=True`.
- Keep the default at FP32 and preserve the existing BF16 path.
- Cast UnifiedVoice/GPT on CPU before moving it to the accelerator, avoiding a
  transient full-FP32 GPT allocation on a low-VRAM GPU.
- Keep the semantic codec, Wav2Vec2-BERT, CAMPPlus, S2Mel, and BigVGAN in FP32.
- Make the WebUI BF16 probe exclude emulation and select FP16 on CUDA devices
  without native BF16 support. The existing `--fp16` flag remains the only
  WebUI flag.

This changes numerical precision and may change generated token sequences,
prosody, or emotion. It does not reduce the model's mathematical operation
count and is not presented as a universal speedup.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation / comments only
- [ ] Build / CI / dependency change
- [ ] Refactor (no behaviour change)

## How has this been tested?

Targeted no-GPU precision tests:

```text
18 passed in 0.12s
```

They cover FP32/FP16/BF16 routing, mutual exclusion, CPU/MPS fallback, XPU API
routing, constructor argument compatibility, WebUI native-BF16/FP16 selection,
and the `including_emulation=False` probe. Three existing IndexTTS-2.5 import
and segmentation tests also pass (`3 passed`, with three unrelated dependency
deprecation warnings).

Exact-commit checkpoint/CUDA smoke for `78b3f369decfcf10b91043a4910b029579fab384`:

- Windows 10, GTX 1060 6 GB (compute capability 6.1), driver 582.66
- Python 3.11.13, PyTorch 2.8.0+cu128, CUDA runtime 12.8
- `use_fp16=True`, `use_bf16=False`, QwenEmotion/DeepSpeed/accel/
  torch.compile/custom CUDA kernel disabled
- dtype placement verified: UnifiedVoice/GPT FP16; Wav2Vec2-BERT, CAMPPlus,
  semantic codec, S2Mel, and BigVGAN FP32
- initialization: 38.883 s; 5025.0/5216.0 MiB allocated/reserved;
  5061.4 MiB maximum allocated
- one 3.228 s output: finite, non-silent, 22.05 kHz mono WAV; no CUDA/OOM
- inference: 295.680 s; 5895.3/6388.0 MiB maximum allocated/reserved

The very slow inference is an important limitation, not a speed result: the
all-CUDA pipeline left only about 133 MiB of physical VRAM free and paged under
WDDM. FP16 makes the GPT stack smaller, but FP16 alone does not guarantee smooth
IndexTTS-2.5 inference on every 6 GB device. A downstream layout which also
keeps reference encoders off GPU has completed 99 cached-reference syntheses on
the same card with no synthesis/CUDA/OOM failures and 3174-3289 MiB peak
allocation; that is supporting deployment evidence, not an exact benchmark of
this PR.

No Ampere/native-BF16, XPU, DeepSpeed, FlashAttention acceleration, custom CUDA
kernel, torch.compile, or multi-GPU hardware was available. Those paths are not
claimed as hardware-validated; maintainer/community verification is welcome.

## Checklist

- [x] Targeted no-GPU tests pass locally.
- [x] Tests cover the new precision-selection behavior.
- [x] The changed public constructor argument is documented.
- [x] Exact-commit CUDA smoke completed on the available GPU.
