### PR TITLE
feat(inference): optionally reuse speaker conditioning for default emotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,25 @@ from indextts.infer_v2_5 import IndexTTS2
 tts = IndexTTS2(cfg_path="checkpoints/config.yaml", model_dir="checkpoints", use_bf16=True)
 ```
 
+IndexTTS-2.5 can optionally reuse the speaker conditioning for the default
+emotion reference:
+
+```python
+tts = IndexTTS2(
+    cfg_path="checkpoints/config.yaml",
+    model_dir="checkpoints",
+    reuse_spk_cond_for_emo=True,
+)
+```
+
+This opt-in mode skips one Wav2Vec2-BERT reference-encoding pass on a cache miss
+and one of the two conditioning-to-emotion-vector projections for each generated
+segment. It does not materially reduce resident memory. Speaker and emotion audio
+normally use different resampling paths, so enabling it may change the resulting
+voice or emotion. Explicit emotion audio, vectors, and text continue to use their
+normal paths. The same option is available in the WebUI as
+`uv run webui.py --reuse_spk_cond_for_emo`; it is not supported by IndexTTS-2.
+
 #### 1. Voice cloning with a single reference audio
 
 ```python

--- a/indextts/infer_v2_5.py
+++ b/indextts/infer_v2_5.py
@@ -76,7 +76,8 @@ def apply_pronunciation_annotations(text: str) -> str:
 class IndexTTS2:
     def __init__(
             self, cfg_path="checkpoints/config.yaml", model_dir="checkpoints", use_bf16=False, device=None,
-            use_cuda_kernel=None,use_deepspeed=False, use_accel=False, use_torch_compile=False, use_qwen_emo=False
+            use_cuda_kernel=None,use_deepspeed=False, use_accel=False, use_torch_compile=False, use_qwen_emo=False,
+            reuse_spk_cond_for_emo=False
     ):
         """
         Args:
@@ -91,6 +92,11 @@ class IndexTTS2:
             use_qwen_emo (bool): if True, load the QwenEmotion text-to-emotion model.
                 Required for ``infer(..., use_emo_text=True)``. Attempting to use emotion-text
                 guidance when this is disabled will raise a RuntimeError.
+            reuse_spk_cond_for_emo (bool): if True, reuse the speaker conditioning as the
+                default emotion conditioning when no explicit emotion audio, vector, or text
+                is supplied. This avoids one reference encoder pass, but may change the output
+                because speaker and emotion audio use different preprocessing paths. It does
+                not materially reduce resident memory.
         """
         if device is not None:
             self.device = device
@@ -120,6 +126,13 @@ class IndexTTS2:
         self.stop_mel_token = self.cfg.gpt.stop_mel_token
         self.use_accel = use_accel
         self.use_torch_compile = use_torch_compile
+        self.reuse_spk_cond_for_emo = reuse_spk_cond_for_emo
+        if self.reuse_spk_cond_for_emo:
+            print(
+                ">> Reusing speaker conditioning for default emotion. This reduces reference "
+                "encoding compute, but may change voice or emotion because the speaker and "
+                "emotion audio preprocessing paths differ."
+            )
 
         # Detect low-VRAM GPUs (< 10 GB) to enable automatic text chunking
         self.low_vram = False
@@ -288,6 +301,48 @@ class IndexTTS2:
         feat = vq_emb.hidden_states[17]  # (B, T, C)
         feat = (feat - self.semantic_mean) / self.semantic_std
         return feat
+
+    def _should_reuse_spk_cond_for_emo(self, emo_audio_prompt, emo_vector, use_emo_text):
+        return (
+            self.reuse_spk_cond_for_emo
+            and emo_audio_prompt is None
+            and emo_vector is None
+            and not use_emo_text
+        )
+
+    def _get_emo_cond_emb(self, emo_audio_prompt, spk_cond_emb, reuse_spk_cond, verbose):
+        if reuse_spk_cond:
+            return spk_cond_emb
+
+        if self.cache_emo_cond is None or self.cache_emo_audio_prompt != emo_audio_prompt:
+            if self.cache_emo_cond is not None:
+                self.cache_emo_cond = None
+                torch.cuda.empty_cache()
+            emo_audio, _ = self._load_and_cut_audio(emo_audio_prompt, 15, verbose, sr=16000)
+            emo_inputs = self.extract_features(emo_audio, sampling_rate=16000, return_tensors="pt")
+            emo_input_features = emo_inputs["input_features"]
+            emo_attention_mask = emo_inputs["attention_mask"]
+            emo_input_features = emo_input_features.to(self.device)
+            emo_attention_mask = emo_attention_mask.to(self.device)
+            emo_cond_emb = self.get_emb(emo_input_features, emo_attention_mask)
+
+            self.cache_emo_cond = emo_cond_emb
+            self.cache_emo_audio_prompt = emo_audio_prompt
+        else:
+            emo_cond_emb = self.cache_emo_cond
+        return emo_cond_emb
+
+    def _get_emovec(self, spk_cond_emb, emo_cond_emb, cond_lengths, emo_cond_lengths,
+                    emo_alpha, reuse_spk_cond):
+        if reuse_spk_cond:
+            return self.gpt.get_emovec(spk_cond_emb, cond_lengths)
+        return self.gpt.merge_emovec(
+            spk_cond_emb,
+            emo_cond_emb,
+            cond_lengths,
+            emo_cond_lengths,
+            alpha=emo_alpha,
+        )
 
     @torch.no_grad()
     def get_scode(self, inputs):
@@ -580,6 +635,12 @@ class IndexTTS2:
                   f"emo_text:{emo_text}")
         start_time = time.perf_counter()
 
+        reuse_spk_cond = self._should_reuse_spk_cond_for_emo(
+            emo_audio_prompt,
+            emo_vector,
+            use_emo_text,
+        )
+
         if use_emo_text or emo_vector is not None:
             # we're using a text or emotion vector guidance; so we must remove
             # "emotion reference voice", to ensure we use correct emotion mixing!
@@ -679,22 +740,12 @@ class IndexTTS2:
             emovec_mat = torch.sum(emovec_mat, 0)
             emovec_mat = emovec_mat.unsqueeze(0)
 
-        if self.cache_emo_cond is None or self.cache_emo_audio_prompt != emo_audio_prompt:
-            if self.cache_emo_cond is not None:
-                self.cache_emo_cond = None
-                torch.cuda.empty_cache()
-            emo_audio, _ = self._load_and_cut_audio(emo_audio_prompt,15,verbose,sr=16000)
-            emo_inputs = self.extract_features(emo_audio, sampling_rate=16000, return_tensors="pt")
-            emo_input_features = emo_inputs["input_features"]
-            emo_attention_mask = emo_inputs["attention_mask"]
-            emo_input_features = emo_input_features.to(self.device)
-            emo_attention_mask = emo_attention_mask.to(self.device)
-            emo_cond_emb = self.get_emb(emo_input_features, emo_attention_mask)
-
-            self.cache_emo_cond = emo_cond_emb
-            self.cache_emo_audio_prompt = emo_audio_prompt
-        else:
-            emo_cond_emb = self.cache_emo_cond
+        emo_cond_emb = self._get_emo_cond_emb(
+            emo_audio_prompt,
+            spk_cond_emb,
+            reuse_spk_cond,
+            verbose,
+        )
 
         self._set_gr_progress(0.1, "text processing...")
         lang_prefix = f'<|{lang.lower()}|> '
@@ -756,12 +807,13 @@ class IndexTTS2:
             m_start_time = time.perf_counter()
             with torch.no_grad():
                 with torch.amp.autocast(text_tokens.device.type, enabled=self.dtype is not None, dtype=self.dtype):
-                    emovec = self.gpt.merge_emovec(
+                    emovec = self._get_emovec(
                         spk_cond_emb,
                         emo_cond_emb,
                         torch.tensor([spk_cond_emb.shape[-1]], device=text_tokens.device),
                         torch.tensor([emo_cond_emb.shape[-1]], device=text_tokens.device),
-                        alpha=emo_alpha
+                        emo_alpha,
+                        reuse_spk_cond,
                     )
 
                     if emo_vector is not None:

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -8,6 +8,7 @@ CI only (no GPU):
     uv run --extra test pytest tests/test_v2.py -v -m "not gpu"
 """
 import importlib
+import inspect
 import sys
 import types
 from pathlib import Path
@@ -384,6 +385,132 @@ def test_qwen_emotion_convert_redirects_cross_key_labels(module_name, monkeypatc
     emotion_dict = emo.convert({"高兴": "自然"})
     assert emotion_dict["happy"] == 0.0
     assert emotion_dict["calm"] == 1.0
+
+
+# -- IndexTTS-2.5 default emotion conditioning reuse (no GPU) -----------------
+
+def _new_v25_reuse_stub(monkeypatch, enabled=True):
+    module = _load_qwen_emotion_module("indextts.infer_v2_5", monkeypatch)
+    tts = module.IndexTTS2.__new__(module.IndexTTS2)
+    tts.reuse_spk_cond_for_emo = enabled
+    return module, tts
+
+
+def test_25_reuse_spk_cond_constructor_option_defaults_off(monkeypatch):
+    module, _ = _new_v25_reuse_stub(monkeypatch)
+    parameter = inspect.signature(module.IndexTTS2.__init__).parameters["reuse_spk_cond_for_emo"]
+
+    assert parameter.default is False
+
+
+@pytest.mark.parametrize(
+    "enabled,emo_audio_prompt,emo_vector,use_emo_text,expected",
+    [
+        (False, None, None, False, False),
+        (True, None, None, False, True),
+        (True, "speaker.wav", None, False, False),
+        (True, None, [0.0] * 8, False, False),
+        (True, None, None, True, False),
+    ],
+)
+def test_25_reuse_spk_cond_only_applies_to_implicit_default_emotion(
+        monkeypatch, enabled, emo_audio_prompt, emo_vector, use_emo_text, expected):
+    _, tts = _new_v25_reuse_stub(monkeypatch, enabled=enabled)
+
+    assert tts._should_reuse_spk_cond_for_emo(
+        emo_audio_prompt,
+        emo_vector,
+        use_emo_text,
+    ) is expected
+
+
+def test_25_reuse_spk_cond_aliases_current_speaker_without_polluting_emo_cache(monkeypatch):
+    _, tts = _new_v25_reuse_stub(monkeypatch)
+    explicit_emo_cond = object()
+    tts.cache_emo_cond = explicit_emo_cond
+    tts.cache_emo_audio_prompt = "emotion.wav"
+    tts._load_and_cut_audio = lambda *args, **kwargs: pytest.fail("emotion audio must not be loaded")
+
+    first_spk_cond = object()
+    second_spk_cond = object()
+    assert tts._get_emo_cond_emb("speaker-a.wav", first_spk_cond, True, False) is first_spk_cond
+    assert tts._get_emo_cond_emb("speaker-b.wav", second_spk_cond, True, False) is second_spk_cond
+    assert tts.cache_emo_cond is explicit_emo_cond
+    assert tts.cache_emo_audio_prompt == "emotion.wav"
+
+
+def test_25_reuse_spk_cond_preserves_explicit_emo_audio_encoder_for_same_path(monkeypatch):
+    _, tts = _new_v25_reuse_stub(monkeypatch)
+    calls = []
+
+    class FakeTensor:
+        def to(self, device):
+            calls.append(("to", device))
+            return self
+
+    input_features = FakeTensor()
+    attention_mask = FakeTensor()
+    encoded_emo = object()
+    tts.device = "cpu"
+    tts.cache_emo_cond = None
+    tts.cache_emo_audio_prompt = None
+
+    def load_audio(*args, **kwargs):
+        calls.append(("load", args, kwargs))
+        return object(), 16000
+
+    tts._load_and_cut_audio = load_audio
+    tts.extract_features = lambda *args, **kwargs: {
+        "input_features": input_features,
+        "attention_mask": attention_mask,
+    }
+    tts.get_emb = lambda features, mask: calls.append(("encode", features, mask)) or encoded_emo
+
+    reuse_spk_cond = tts._should_reuse_spk_cond_for_emo("speaker.wav", None, False)
+    result = tts._get_emo_cond_emb("speaker.wav", object(), reuse_spk_cond, False)
+
+    assert reuse_spk_cond is False
+    assert result is encoded_emo
+    assert [call[0] for call in calls].count("load") == 1
+    assert [call[0] for call in calls].count("encode") == 1
+    assert tts.cache_emo_cond is encoded_emo
+    assert tts.cache_emo_audio_prompt == "speaker.wav"
+
+    assert tts._get_emo_cond_emb("speaker.wav", object(), False, False) is encoded_emo
+    assert [call[0] for call in calls].count("load") == 1
+    assert [call[0] for call in calls].count("encode") == 1
+
+
+def test_25_reuse_spk_cond_fast_path_uses_single_emovec_encoding(monkeypatch):
+    _, tts = _new_v25_reuse_stub(monkeypatch)
+
+    class FakeGpt:
+        def __init__(self):
+            self.get_calls = []
+            self.merge_calls = []
+
+        def get_emovec(self, cond, lengths):
+            self.get_calls.append((cond, lengths))
+            return "reused-emovec"
+
+        def merge_emovec(self, *args, **kwargs):
+            self.merge_calls.append((args, kwargs))
+            return "merged-emovec"
+
+    tts.gpt = FakeGpt()
+    spk_cond = object()
+    emo_cond = object()
+    spk_lengths = object()
+    emo_lengths = object()
+
+    assert tts._get_emovec(spk_cond, spk_cond, spk_lengths, spk_lengths, 1.0, True) == "reused-emovec"
+    assert len(tts.gpt.get_calls) == 1
+    assert tts.gpt.merge_calls == []
+
+    assert tts._get_emovec(spk_cond, emo_cond, spk_lengths, emo_lengths, 0.5, False) == "merged-emovec"
+    assert len(tts.gpt.get_calls) == 1
+    assert len(tts.gpt.merge_calls) == 1
+    assert tts.gpt.merge_calls[0][1] == {"alpha": 0.5}
 
 
 # -- Inference (GPU required) --------------------------------------------------

--- a/tests/test_webui_syntax.py
+++ b/tests/test_webui_syntax.py
@@ -6,3 +6,12 @@ def test_webui_python_source_parses():
     source = webui_path.read_text(encoding="utf-8")
 
     assert compile(source, str(webui_path), "exec") is not None
+
+
+def test_webui_wires_spk_condition_reuse_to_v25_only():
+    webui_path = Path(__file__).resolve().parents[1] / "webui.py"
+    source = webui_path.read_text(encoding="utf-8")
+
+    assert '"--reuse_spk_cond_for_emo"' in source
+    assert 'cmd_args.reuse_spk_cond_for_emo and cmd_args.version != "2.5"' in source
+    assert 'kwargs["reuse_spk_cond_for_emo"] = cmd_args.reuse_spk_cond_for_emo' in source

--- a/webui.py
+++ b/webui.py
@@ -32,8 +32,19 @@ parser.add_argument("--cuda_kernel", action="store_true", default=False, help="U
 parser.add_argument("--accel", action="store_true", default=False, help="Use GPT2 acceleration engine if available")
 parser.add_argument("--torch_compile", action="store_true", default=False, help="Use torch.compile to optimize s2mel if available")
 parser.add_argument("--qwen_emo", action="store_true", default=False, help="Load QwenEmotion even on a low-VRAM GPU, where it is skipped by default")
+parser.add_argument(
+    "--reuse_spk_cond_for_emo",
+    action="store_true",
+    default=False,
+    help=(
+        "IndexTTS-2.5 only: reuse speaker conditioning for the default emotion to reduce "
+        "reference encoding compute; this may change voice or emotion"
+    ),
+)
 parser.add_argument("--gui_seg_tokens", type=int, default=120, help="GUI: Max tokens per generation segment")
 cmd_args = parser.parse_args()
+if cmd_args.reuse_spk_cond_for_emo and cmd_args.version != "2.5":
+    parser.error("--reuse_spk_cond_for_emo is only supported with --version 2.5")
 
 # Validate optional acceleration dependencies early, so missing extras fail
 # at startup instead of halfway through inference.
@@ -155,6 +166,7 @@ def build_tts(use_accel=False, use_torch_compile=False):
         if HALF_PRECISION and not use_bf16:
             print(">> BF16 is not supported on this device, falling back to full precision.")
         kwargs["use_bf16"] = use_bf16
+        kwargs["reuse_spk_cond_for_emo"] = cmd_args.reuse_spk_cond_for_emo
     else:
         kwargs["use_fp16"] = HALF_PRECISION
     return IndexTTS2(**kwargs)


### PR DESCRIPTION
## Description

Add an explicit, disabled-by-default IndexTTS-2.5 option to reuse speaker
conditioning as the implicit/default emotion conditioning:

```python
IndexTTS2(..., reuse_spk_cond_for_emo=True)
```

The WebUI exposes the same setting as `--reuse_spk_cond_for_emo` for version
2.5 and rejects it for version 2.

The fast path is used only when the caller supplies no `emo_audio_prompt`, no
`emo_vector`, and does not enable `use_emo_text`. Explicit emotion audio keeps
its independent preprocessing even when its path equals the speaker path.
Emotion vectors and emotion text also keep the existing path.

When active, the implementation:

- aliases the current `spk_cond_emb` as `emo_cond_emb` without writing it into
  the general emotion-reference cache;
- skips one separate emotion-reference Wav2Vec2-BERT pass on a reference cache
  miss; and
- calls `get_emovec()` once per generated segment instead of calling it twice
  through `merge_emovec()` for identical conditions with the default alpha of
  1.0.

## Why this is opt-in

The speaker and emotion paths do not currently produce identical conditioning:
speaker audio is loaded at 22.05 kHz and then resampled to 16 kHz by TorchAudio,
while emotion audio is loaded directly at 16 kHz by librosa. Reusing the
speaker result is therefore a compute/quality trade-off and may change voice or
emotion. The default remains `False`, and this is not tied automatically to
device, precision, or low-VRAM detection.

No meaningful resident-memory saving is claimed. Reference Wav2Vec work is
also already avoided on a warm cache; the continuing benefit is the single
`get_emovec()` call for each generated segment.

On current `main` (`ee40fa7`), a cold default reference uses two speaker
Wav2Vec forwards plus one emotion forward. This PR removes only the separate
emotion forward, so the total is **3 -> 2**. It deliberately leaves the
unrelated redundant speaker work reported in #796 unchanged.

As directional hardware evidence, a separate GTX 1060 reference-device test
measured the default emotion-reference miss at 8.175 s and its cache hit below
0.001 s. That measurement is documented in
[PR #795's validation comment](https://github.com/index-tts/index-tts/pull/795#issuecomment-5425234111);
it is not presented as an exact-branch benchmark for this PR.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation / comments only
- [ ] Build / CI / dependency change
- [ ] Refactor (no behaviour change)

## How has this been tested?

The full no-GPU suite was run on Windows with Python 3.11.13 and the existing
IndexTTS dependency environment:

```text
pytest -m "not gpu"
173 passed, 22 deselected, 30 subtests passed
```

New CPU/mock coverage verifies:

- the constructor option defaults to `False`;
- only implicit/default emotion selects the alias;
- explicit emotion audio (including the same path), vectors, and text do not;
- changing the speaker uses the current speaker condition and does not pollute
  an existing explicit emotion cache;
- the fast path calls `get_emovec()` once and does not call `merge_emovec()`;
  and
- the WebUI flag is wired only to IndexTTS-2.5.

No checkpoint or GPU model was loaded for this PR. BF16, DeepSpeed, acceleration
engines, multi-GPU, and perceptual audio A/B were not hardware-regressed; the
default path is unchanged, and community testing of the opt-in output is
welcome.

## Checklist

- [x] Tests pass locally: `uv run pytest -m "not gpu"` (no GPU) or `uv run pytest tests/test_v2.py` (with GPU)
- [x] I have added or updated tests to cover my changes (where applicable).
- [x] I have added or updated docstrings for any changed public functions.

## Screenshots / output (if relevant)

Not applicable.
