### PR TITLE
fix: scale text-segment token budget for non-CJK languages

### DIFF
--- a/indextts/infer_v2_5.py
+++ b/indextts/infer_v2_5.py
@@ -410,6 +410,15 @@ class IndexTTS2:
 
     SPLIT_PROTECTED_PATTERN = re.compile(r'<\|SPECIAL_TOKEN_\d+\|>.*?<\|SPECIAL_TOKEN_\d+\|>')
 
+    # Text-token density differs by script: CJK speech carries ~4.3 text tokens
+    # per second of audio vs ~3.1 for Latin-script languages (measured in #775).
+    # The same token budget therefore allows ~1.4x longer single-segment audio
+    # outside CJK, past the ~25-30s range where GPT alignment stays stable.
+    # Scale non-CJK budgets so one segment maps to the same audio duration as
+    # CJK at the same budget.
+    CJK_LANGS = {"zh", "zhen", "ja", "ko", "yue"}
+    NON_CJK_BUDGET_SCALE = 3.1 / 4.3
+
     def _token_len(self, text):
         return len(self.tokenizer.encode(text, allowed_special='all'))
 
@@ -427,6 +436,9 @@ class IndexTTS2:
     def split_text_by_tokens(self, text, max_tokens, lang_prefix=""):
         capacity = self.gpt.text_pos_embedding.emb.num_embeddings
         budget = min(max_tokens, capacity - 2) - self._token_len(lang_prefix)
+        lang_match = re.match(r"<\|([^|]+)\|>", lang_prefix)
+        if lang_match and lang_match.group(1).lower() not in self.CJK_LANGS:
+            budget = int(budget * self.NON_CJK_BUDGET_SCALE)
         budget = max(1, budget)
         if self._token_len(text) <= budget:
             return [text]

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -256,6 +256,45 @@ def test_split_leaves_short_text_alone():
     assert splitter.split_text_by_tokens(text, 120, "<|zh|> ") == [text]
 
 
+def test_split_scales_budget_for_latin_scripts():
+    """Non-CJK budgets must map to CJK-equivalent audio duration (#775).
+
+    Latin-script text carries ~3.1 speech-seconds per text token vs ~4.3 for
+    CJK, so the same budget lets one English segment run ~1.4x longer before
+    GPT alignment destabilizes. With the 1-token-per-char stub and prefix
+    "<|en|> " (7 chars), budget 120 gives 113, scaled by 3.1/4.3 to 79. The
+    fixture fits the unscaled budget (one segment before the fix) but must be
+    split under the scaled one.
+    """
+    splitter = _splitter_stub()
+    text = (
+        "A quick brown fox jumps over the lazy dog near the riverbank at sunrise. "
+        "Some more words follow here. "
+    )
+    unscaled = 120 - len("<|en|> ")
+    budget = int(unscaled * (3.1 / 4.3))
+    assert budget < splitter._token_len(text) <= unscaled, "fixture must straddle the two budgets"
+
+    segments = splitter.split_text_by_tokens(text, 120, "<|en|> ")
+    assert len(segments) > 1, "English text must be split under the scaled budget"
+    for s in segments:
+        assert splitter._token_len(s) <= budget, f"segment exceeds scaled budget: {len(s)}"
+
+
+def test_split_keeps_cjk_budget_unchanged():
+    """CJK languages keep the unscaled budget: 50 chars <= 120-7 stays one segment."""
+    splitter = _splitter_stub()
+    text = "各种应用层出不穷，而语音合成作为人机交互的重要一环。" * 2
+    assert splitter.split_text_by_tokens(text, 120, "<|zh|> ") == [text]
+
+
+def test_split_latin_short_text_stays_single():
+    """Short Latin-script text must not be over-split by the scaled budget."""
+    splitter = _splitter_stub()
+    text = "Hello world, this is a short check."
+    assert splitter.split_text_by_tokens(text, 120, "<|en|> ") == [text]
+
+
 def _load_qwen_emotion_module(module_name, monkeypatch):
     class _Dummy:
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Problem

`max_text_tokens_per_segment` (default 120) is the only gate that keeps a single synthesized segment inside the audio-length range where GPT alignment stays stable. That budget is calibrated on CJK token density: Chinese speech runs **~4.3 text tokens per second** of audio, but Latin-script languages run **~3.1 tokens/s** (measured in #775 with controlled experiments). The same budget therefore allows **~1.4x longer single-segment audio** for English — ~38s vs the ~25–30s stability boundary.

Two code paths combine to make this invisible for short-looking paragraphs:

1. `split_text_by_tokens()` returns the whole text as one segment as soon as its token count fits the budget (`indextts/infer_v2_5.py`), so a 5-sentence English paragraph under 120 tokens is never split at sentence boundaries.
2. `max_mel_tokens` never trips in these cases (only ~800 of 1500 used), so the user gets no warning — just a last sentence that is fluent but wrong.

In #775 the reporter shows 8/8 failures with the default budget vs 5/5 correct at budget 60, and 3/3 correct for a Chinese translation of the same content — because the Chinese version exceeds 120 tokens and gets split. The deciding quantity is single-segment audio duration, not token count.

Fixes #775.

## What changed

`split_text_by_tokens()` now scales the effective budget for non-CJK languages by the measured density ratio (**3.1 / 4.3 ≈ 0.72**), so one segment maps to the same *audio duration* as CJK at the same budget:

- CJK languages (`zh`, `zhen`, `ja`, `ko`, `yue`) keep the exact budget — their behavior is unchanged bit-for-bit.
- The language is read from `lang_prefix` (`<|en|> `, `<|zh|> `, …), which the function already receives.
- The webui segment-preview table calls the same function, so what the user sees in the preview stays identical to what inference uses — no second copy of the policy.
- An empty `lang_prefix` (no language known) keeps the unscaled budget, to stay conservative.

This follows suggestion 2 from the issue, with the parity factor derived from the reported densities rather than hard-coding an English-specific value: at budget 120 English segments now max out at ~86 tokens ≈ 28s, matching what a 120-token Chinese segment costs, instead of ~38s.

## Verification

CI-equivalent locally (`pytest -m "not gpu"`, Windows, Python 3.10): **30 passed, 22 deselected (gpu)**.

Three regression tests added to the existing no-GPU stub suite in `tests/test_v2.py`:

- `test_split_scales_budget_for_latin_scripts` — a two-sentence English fixture that fits the unscaled budget but not the scaled one. With the fix stashed this test **fails** (single oversized segment); with the fix it passes and every segment is within the scaled budget.
- `test_split_keeps_cjk_budget_unchanged` — CJK text at the same budget is returned unsplit, guarding against accidentally scaling CJK too.
- `test_split_latin_short_text_stays_single` — short English text must not be over-split by the scaled budget.

The three pre-existing split tests (annotation pairing, position-embedding capacity, short-text pass-through) pass unchanged.

The end-to-end effect (last-sentence alignment collapse recovered) requires GPU inference with the 2.5 checkpoints and ASR scoring; the controlled before/after evidence for that is in #775 (18 runs across two reference audios and five seeds). This PR adds the unit-level proof that the budget mechanism now splits English paragraphs and the regression guard that CJK behavior is untouched.

## Note

The v2 (non-2.5) path `Tokenizer.split_segments` in `indextts/utils/front.py` has the same CJK-calibrated budget; I left it out of this PR to keep the change scoped to the version the issue demonstrates.
